### PR TITLE
Improve Multiplayer Support

### DIFF
--- a/garrysmod/garrysmod/addons/remixbinary/lua/autorun/cl_rtx.lua
+++ b/garrysmod/garrysmod/addons/remixbinary/lua/autorun/cl_rtx.lua
@@ -1,5 +1,11 @@
 if not CLIENT then return end
 
+-- Prevents client side lua errors in multiplayer since not every client may have RTX installed
+if not game.SinglePlayer() and not util.IsBinaryModuleInstalled("RTXFixesBinary") then
+    print("[gmRTX-cl] RTX Fixes binary module not installed, skipping client side code load.")
+    return
+end
+
 if CLIENT then
     require((BRANCH == "x86-64" or BRANCH == "chromium" ) and "RTXFixesBinary" or "RTXFixesBinary")
 end

--- a/garrysmod/garrysmod/addons/remixbinary/lua/autorun/sv_rtx.lua
+++ b/garrysmod/garrysmod/addons/remixbinary/lua/autorun/sv_rtx.lua
@@ -31,7 +31,7 @@ if (SERVER) then
 			end
 			
 			-- Send client files to clients
-			local clientFolders = {"remixlua/cl/", "remixlua/cl/remixapi/"}
+			local clientFolders = {"remixlua/cl/", "remixlua/cl/remixapi/", "remixlua/cl/remixapi/wrappers/", "remixlua/cl/customrender/"}
 			for _, folder in ipairs(clientFolders) do
 				local files, _ = file.Find(folder .. "*.lua", "LUA")
 				if files then


### PR DESCRIPTION
Fixes `AddCSLuaFile` not being called on some client lua files (required for multiplayer).
Return early in the client side init if the RTX binary is not installed and the current game is multiplayer. Prevents client side errors on non-RTX clients.