### PR TITLE
Add native RTX material override bridge for editing Remix Related Materials in game

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,14 @@ jobs:
     
     - name: Build
       run: msbuild RTXFixesBinary.sln /p:Configuration=Release /p:Platform=${{ matrix.platform }} /m
+
+    - name: Test Advanced Material Editor RTX writer
+      if: matrix.platform == 'x64'
+      run: |
+        cmake -S source/advmat_rtx_bridge -B out/advmat-rtx-bridge -G "Visual Studio 17 2022" -A x64
+        cmake --build out/advmat-rtx-bridge --config Release
+        ctest --test-dir out/advmat-rtx-bridge -C Release --output-on-failure
+      shell: pwsh
     
     - name: Prepare artifacts
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build_remote.sh
 /garrysmod/garrysmod/addons/mw_twr
 /garrysmod/garrysmod/addons/mwbase_original
 .worktrees/
+/out/advmat-rtx-bridge/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 - ToPBR: Automatically converts Source Engine materials to PBR at runtime
 - Hardware Skinning (For Half-Life 2 RTX Assets)
 - Remix API Support (including Lua bindings for addon creation)
+  - Win64 legacy texture-hash replacement provider for Advanced Material Editor
+    ([protocol and safety notes](source/advmat_rtx_bridge/README.md))
       
 ## Installation
 - Switch to the `x86-64` branch of Garry's Mod on Steam

--- a/premake5.lua
+++ b/premake5.lua
@@ -53,6 +53,19 @@ CreateWorkspace({name = "RTXFixesBinary", abi_compatible = false, path = ""})
 			"source/material_pipeline/to_pbr/*.h",
 		} 
 
+		filter({"system:windows", "platforms:x86_64"})
+			includedirs("source/advmat_rtx_bridge/include")
+			files {
+				"source/advmat_rtx_bridge/src/bridge.cpp",
+				"source/advmat_rtx_bridge/src/filesystem_utils.cpp",
+				"source/advmat_rtx_bridge/src/internal.h",
+				"source/advmat_rtx_bridge/src/lua_bindings.cpp",
+				"source/advmat_rtx_bridge/src/texture_ingest.cpp",
+				"source/advmat_rtx_bridge/src/usda_writer.cpp",
+				"source/advmat_rtx_bridge/include/advmat_rtx_bridge/*.h",
+			}
+			links({"windowscodecs", "ole32"})
+			exceptionhandling("On")
 
 		filter("system:windows")
 			files({"source/win32/*.cpp", "source/win32/*.hpp"})

--- a/source/advmat_rtx_bridge/CMakeLists.txt
+++ b/source/advmat_rtx_bridge/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.20)
+project(advmat_rtx_bridge_writer VERSION 1.0.0 LANGUAGES CXX)
+
+option(ADVMAT_RTX_BUILD_TESTS "Build the pure writer contract tests" ON)
+
+function(advmat_rtx_strict_compile target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /WX /permissive- /EHsc)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    endif()
+endfunction()
+
+add_library(advmat_rtx_writer STATIC
+    src/bridge.cpp
+    src/filesystem_utils.cpp
+    src/texture_ingest.cpp
+    src/usda_writer.cpp)
+target_include_directories(advmat_rtx_writer PUBLIC include PRIVATE src)
+target_compile_features(advmat_rtx_writer PUBLIC cxx_std_17)
+set_target_properties(advmat_rtx_writer PROPERTIES POSITION_INDEPENDENT_CODE ON)
+advmat_rtx_strict_compile(advmat_rtx_writer)
+
+if(WIN32)
+    target_link_libraries(advmat_rtx_writer PRIVATE windowscodecs ole32)
+endif()
+
+if(ADVMAT_RTX_BUILD_TESTS)
+    enable_testing()
+    add_executable(advmat_rtx_writer_tests tests/writer_tests.cpp)
+    target_link_libraries(advmat_rtx_writer_tests PRIVATE advmat_rtx_writer)
+    target_compile_features(advmat_rtx_writer_tests PRIVATE cxx_std_17)
+    advmat_rtx_strict_compile(advmat_rtx_writer_tests)
+    add_test(NAME advmat_rtx_writer_tests COMMAND advmat_rtx_writer_tests)
+endif()

--- a/source/advmat_rtx_bridge/README.md
+++ b/source/advmat_rtx_bridge/README.md
@@ -1,0 +1,102 @@
+# Advanced Material Editor RTX bridge
+
+This directory contains the Win64 compatibility provider used by Advanced
+Material Editor. It is compiled into `RTXFixesBinary`; it is not a second
+Garry's Mod binary module.
+
+The provider exposes the global `AdvMatRTXBridge` protocol 1 table to client
+Lua:
+
+- `Capabilities()`
+- `ApplyLegacyMaterial(request)`
+- `ClearLegacyMaterial(request)`
+- `ClearAllOwned({ protocol = 1 })`
+
+### Protocol 1 shape
+
+`ApplyLegacyMaterial` accepts one transaction containing `protocol = 1`,
+`operation = "commit"`, a stable `target.material` string, one to 128 exact
+64-bit hexadecimal strings in `hashes`, and material data in
+`compiled.pbr` (or the equivalent `profile.pbr` compatibility field):
+
+```lua
+local ok, resultOrError = AdvMatRTXBridge.ApplyLegacyMaterial({
+    protocol = 1,
+    operation = "commit",
+    target = { material = "models/example/material" },
+    hashes = { "0123456789ABCDEF" },
+    compiled = { pbr = {
+        constants = { roughness = 0.4, metallic = 0.0 },
+        maps = {
+            albedo = "<UTF-8 game-root-contained path>",
+            normal = { source = "<path>", ops = {} },
+        },
+        options = { filter_mode = "linear", wrap_u = "repeat", wrap_v = "repeat" },
+    } },
+})
+```
+
+`ClearLegacyMaterial` accepts `protocol`, `target`, and the exact `hashes` to
+remove; `ClearAllOwned` accepts only the protocol and never accepts a path.
+Success returns `true` plus a table containing `code`, `profileId`,
+`layerPath`, `layerPaths`, and `importedTextures`. Failure returns `false`
+plus a `code: message` string. `Capabilities()` reports protocol support,
+writer/reset features, texture conversion support, configured limits, and the
+fixed owned mod directory. The authoritative field parsing and complete PBR
+surface are defined by
+[`lua_bindings.cpp`](src/lua_bindings.cpp) and
+[`bridge.h`](include/advmat_rtx_bridge/bridge.h).
+
+The public Remix material API creates materials for Remix API-owned geometry.
+This bridge provides the separate operation the addon needs: persistent PBR
+replacement of already-captured Source draw-call texture hashes.
+
+## Ownership and safety
+
+The writer owns only:
+
+```text
+<Garry's Mod>/rtx-remix/mods/!advanced_material_editor/
+```
+
+It never reads, changes, or removes `~gmod_topbr`. Exact 64-bit hashes remain
+strings from Lua through USDA authoring. `mod.usda` is the only activation
+ledger and is published after its immutable, content-revisioned dependencies.
+Exact-hash clears cannot remove another replacement for the same Source
+material.
+
+Protocol 1 is commit-only. `livePreview` is false and preview requests are
+rejected before filesystem work. `ClearAllOwned` atomically publishes an
+empty root before retiring prior profile and texture generations, preventing
+persistent overrides from leaking between server sessions.
+
+Inputs are confined to validated game-root descendants. Default limits are
+32 MiB per source/output texture, 2048 pixels per axis, four texture
+operations, and 128 hashes per transaction. The published set is additionally
+bounded to 4096 active hash profiles, 8192 referenced texture files, and 2 GiB
+of referenced texture data. Limits are checked before root publication, so a
+rejected transaction preserves the previous active material state. Immutable
+replacement staging plus the single retired reset generation can temporarily
+use up to four times the active texture budget on disk; the next transaction
+prunes superseded active files and a later reset replaces the retired set.
+If a pre-existing root already exceeds the configured profile limit, ordinary
+apply/clear calls reject it, while `ClearAllOwned` remains available as the
+authoritative recovery path. Its empty-root deactivation is constant-time;
+retiring and cleaning the previous generation is bounded but may be linear in
+the number of owned files.
+
+## Pure writer tests
+
+The tests do not load Garry's Mod or RTX Remix:
+
+```powershell
+cmake -S source/advmat_rtx_bridge -B out/advmat-rtx-bridge -A x64
+cmake --build out/advmat-rtx-bridge --config Release
+ctest --test-dir out/advmat-rtx-bridge -C Release --output-on-failure
+```
+
+They cover localized paths, path and value validation, structural DDS/WIC
+ingestion and corrupt-cache repair, texture-operation limits, normal-map mip
+normalization, atomic multi-hash publication and rollback, unchanged-commit
+reuse, exact-hash/idempotent clears, aggregate-layer migration,
+resource-quota rollback, and authoritative reset/quarantine rotation.

--- a/source/advmat_rtx_bridge/include/advmat_rtx_bridge/bridge.h
+++ b/source/advmat_rtx_bridge/include/advmat_rtx_bridge/bridge.h
@@ -1,0 +1,243 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace advmat::rtx_bridge {
+
+inline constexpr int kApiVersion = 1;
+inline constexpr std::uintmax_t kDefaultMaxTextureBytes = 32ull * 1024ull * 1024ull;
+inline constexpr std::uint32_t kDefaultMaxTextureDimension = 2048;
+inline constexpr std::size_t kDefaultMaxActiveProfiles = 4096;
+inline constexpr std::size_t kDefaultMaxActiveTextureFiles = 8192;
+inline constexpr std::uintmax_t kDefaultMaxActiveTextureBytes =
+    2ull * 1024ull * 1024ull * 1024ull;
+inline constexpr std::size_t kMaxTextureOperations = 4;
+inline constexpr std::size_t kMaxGameRootAncestorDepth = 6;
+
+struct Vec3 {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+enum class TextureRole {
+    Albedo,
+    Normal,
+    Anisotropy,
+    Roughness,
+    Metallic,
+    Height,
+    Emissive,
+    SubsurfaceTransmittance,
+    SubsurfaceThickness,
+    SubsurfaceScattering,
+    SubsurfaceRadius,
+};
+
+inline constexpr std::size_t kTextureRoleCount = 11;
+
+enum class TextureOperationKind {
+    Invert,
+    Multiply,
+    NormalFromHeight,
+};
+
+enum class HeightChannel {
+    Luminance,
+    Red,
+    Green,
+    Blue,
+    Alpha,
+};
+
+// Protocol 1 deliberately supports persistent commits only. Preview remains a
+// parsed operation so both the Lua binding and the writer reject it explicitly
+// instead of accidentally publishing a persistent USDA layer.
+enum class BridgeOperation {
+    Commit,
+    Preview,
+    Restore,
+    Clear,
+};
+
+struct TextureOperation {
+    TextureOperationKind kind = TextureOperationKind::Invert;
+    Vec3 color{1.0f, 1.0f, 1.0f};
+    float strength = 1.0f;
+    HeightChannel channel = HeightChannel::Luminance;
+};
+
+struct TextureInput {
+    TextureRole role = TextureRole::Albedo;
+    std::filesystem::path source;
+    std::vector<TextureOperation> operations;
+};
+
+// Mirrors the fields accepted by RemixMaterial.CreateOpaqueMaterial. Every
+// value is optional so the generated layer only authors values the editor owns.
+struct MaterialParameters {
+    std::vector<TextureInput> textures;
+
+    std::optional<Vec3> albedo;
+    std::optional<float> opacity;
+    std::optional<float> roughness;
+    std::optional<float> metallic;
+    std::optional<Vec3> emissiveColor;
+    std::optional<float> emissiveIntensity;
+    std::optional<float> anisotropy;
+    std::optional<float> thinFilmThickness;
+    std::optional<float> displaceIn;
+    std::optional<float> displaceOut;
+    std::optional<Vec3> subsurfaceTransmittanceColor;
+    std::optional<float> subsurfaceMeasurementDistance;
+    std::optional<Vec3> subsurfaceSingleScatteringAlbedo;
+    std::optional<float> subsurfaceVolumetricAnisotropy;
+    std::optional<Vec3> subsurfaceRadius;
+    std::optional<float> subsurfaceRadiusScale;
+    std::optional<float> subsurfaceMaxSampleRadius;
+
+    std::optional<int> spriteSheetRows;
+    std::optional<int> spriteSheetColumns;
+    std::optional<int> spriteSheetFps;
+    std::optional<int> filterMode;
+    std::optional<int> wrapModeU;
+    std::optional<int> wrapModeV;
+    std::optional<int> normalEncoding;
+    std::optional<bool> enableThinFilm;
+    std::optional<bool> enableEmission;
+    std::optional<bool> preloadTextures;
+    std::optional<bool> ignoreMaterial;
+    std::optional<bool> alphaIsThinFilmThickness;
+    std::optional<bool> useDrawCallAlphaState;
+    std::optional<bool> blendEnabled;
+    std::optional<bool> invertedBlend;
+    std::optional<bool> subsurfaceDiffusionProfile;
+    std::optional<int> blendType;
+    std::optional<int> alphaTestType;
+    // AperturePBR expects a normalized floating-point threshold. The legacy
+    // RemixMaterial compatibility table may still supply a byte, which the Lua
+    // binding normalizes before it reaches this writer-owned representation.
+    std::optional<float> alphaReferenceValue;
+};
+
+struct ApplyRequest {
+    BridgeOperation operation = BridgeOperation::Commit;
+    // Stable material-derived identity used for the imported-texture folder
+    // and one-time migration of the older aggregate layer format.
+    std::string profileId;
+    // Persistent layers themselves are keyed one-per-canonical captured hash.
+    std::vector<std::string> hashes;
+    MaterialParameters material;
+};
+
+struct ClearRequest {
+    std::string profileId;
+    // Required exact hashes. Broad material-derived clear is intentionally not
+    // supported because a delayed tombstone must not remove a newer hash.
+    std::vector<std::string> hashes;
+};
+
+struct Result {
+    bool ok = false;
+    std::string code;
+    std::string message;
+    std::string profileId;
+    std::filesystem::path layerPath;
+    std::vector<std::filesystem::path> layerPaths;
+    std::vector<std::filesystem::path> importedTextures;
+
+    static Result Success(std::string profileId = {});
+    static Result Failure(std::string code, std::string message);
+};
+
+struct Capabilities {
+    int apiVersion = kApiVersion;
+    bool available = true;
+    bool legacyUsdaWriter = true;
+    bool livePreview = false;
+    bool authoritativeReset = true;
+    bool atomicProfileLayers = true;
+    bool ddsImport = true;
+    bool wicImageConversion = false;
+    bool textureOperations = false;
+    bool synchronous = true;
+    std::uintmax_t maxTextureBytes = kDefaultMaxTextureBytes;
+    std::uint32_t maxTextureDimension = kDefaultMaxTextureDimension;
+    std::size_t maxTextureOperations = kMaxTextureOperations;
+    std::size_t maxActiveProfiles = kDefaultMaxActiveProfiles;
+    std::size_t maxActiveTextureFiles = kDefaultMaxActiveTextureFiles;
+    std::uintmax_t maxActiveTextureBytes = kDefaultMaxActiveTextureBytes;
+    std::filesystem::path modDirectory;
+};
+
+struct Config {
+    // Garry's Mod installation root (the directory containing hl2.exe and
+    // rtx-remix). The mod destination is deliberately not configurable.
+    std::filesystem::path gameRoot;
+
+    // Texture sources must resolve below one of these roots. When empty, the
+    // canonical game root is the sole import root.
+    std::vector<std::filesystem::path> allowedTextureRoots;
+
+    // Native calls run synchronously on the caller (normally Garry's Mod's
+    // client/game thread). Keep defaults deliberately conservative.
+    std::uintmax_t maxTextureBytes = kDefaultMaxTextureBytes;
+    std::uint32_t maxTextureDimension = kDefaultMaxTextureDimension;
+
+    // Bound the active replacement set and its referenced texture cache.
+    // These limits are evaluated prospectively before the root layer is
+    // published, so a rejected transaction leaves the previous state active.
+    std::size_t maxActiveProfiles = kDefaultMaxActiveProfiles;
+    std::size_t maxActiveTextureFiles = kDefaultMaxActiveTextureFiles;
+    std::uintmax_t maxActiveTextureBytes = kDefaultMaxActiveTextureBytes;
+
+    // Test-only deterministic failure injection. Production integrations must
+    // leave this empty. A true result aborts at the named pre/post-commit point.
+    std::function<bool(std::string_view)> failureInjector;
+};
+
+class Bridge {
+public:
+    explicit Bridge(Config config);
+
+    Capabilities GetCapabilities() const;
+    Result ApplyLegacyMaterial(const ApplyRequest& request);
+    Result ClearLegacyMaterial(const ClearRequest& request);
+    // Disables every active layer in the bridge's fixed owned namespace. No
+    // caller-provided filesystem path participates in this operation.
+    Result ClearAllOwned();
+
+    const std::filesystem::path& ModDirectory() const noexcept;
+
+private:
+    struct Impl;
+    Impl* impl_;
+
+public:
+    ~Bridge();
+    Bridge(const Bridge&) = delete;
+    Bridge& operator=(const Bridge&) = delete;
+    Bridge(Bridge&&) noexcept;
+    Bridge& operator=(Bridge&&) noexcept;
+};
+
+// Strict helpers are public so the writer contract can be tested without Lua.
+bool ValidateProfileId(const std::string& value, std::string& error);
+bool CanonicalizeHash(const std::string& value, std::string& canonical, std::string& error);
+bool ParseBridgeOperation(const std::string& value, BridgeOperation& operation,
+                          std::string& error);
+// Starting at the executable's directory, checks a bounded ancestor chain for
+// a directory containing both garrysmod/ and rtx-remix/. Relative paths and
+// unvalidated current-directory fallbacks are intentionally rejected.
+std::optional<std::filesystem::path> FindGameRootFromExecutable(
+    const std::filesystem::path& executablePath);
+const char* TextureRoleName(TextureRole role) noexcept;
+
+} // namespace advmat::rtx_bridge

--- a/source/advmat_rtx_bridge/include/advmat_rtx_bridge/lua_bindings.h
+++ b/source/advmat_rtx_bridge/include/advmat_rtx_bridge/lua_bindings.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <filesystem>
+
+namespace GarrysMod::Lua { class ILuaBase; }
+
+namespace advmat::rtx_bridge {
+
+// Registers the global AdvMatRTXBridge table. The game root must be the
+// directory containing hl2.exe and rtx-remix. Call this on the client realm.
+bool RegisterLua(GarrysMod::Lua::ILuaBase* lua, const std::filesystem::path& gameRoot);
+void UnregisterLua(GarrysMod::Lua::ILuaBase* lua);
+
+} // namespace advmat::rtx_bridge
+
+

--- a/source/advmat_rtx_bridge/src/bridge.cpp
+++ b/source/advmat_rtx_bridge/src/bridge.cpp
@@ -1,0 +1,1217 @@
+#include "advmat_rtx_bridge/bridge.h"
+#include "internal.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace advmat::rtx_bridge {
+namespace {
+
+constexpr std::uintmax_t kMaximumLegacyLayerBytes = 4ull * 1024ull * 1024ull;
+
+bool TextFileEquals(const std::filesystem::path& path, std::string_view expected) {
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(path, ec) || ec ||
+        std::filesystem::file_size(path, ec) != expected.size() || ec) {
+        return false;
+    }
+
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        return false;
+    }
+    std::array<char, 4096> buffer{};
+    std::size_t offset = 0;
+    while (offset < expected.size()) {
+        const auto count = std::min(buffer.size(), expected.size() - offset);
+        input.read(buffer.data(), static_cast<std::streamsize>(count));
+        if (input.gcount() != static_cast<std::streamsize>(count) ||
+            !std::equal(buffer.begin(), buffer.begin() + static_cast<std::ptrdiff_t>(count),
+                        expected.begin() + static_cast<std::ptrdiff_t>(offset))) {
+            return false;
+        }
+        offset += count;
+    }
+    return true;
+}
+
+bool ReadTextFileBounded(const std::filesystem::path& path, std::uintmax_t maximum,
+                         std::string& contents, std::string& error) {
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec || size > maximum) {
+        error = ec ? "cannot inspect text file: " + ec.message() :
+                     "text file exceeds the safety limit";
+        return false;
+    }
+    contents.resize(static_cast<std::size_t>(size));
+    std::ifstream input(path, std::ios::binary);
+    if (!input || (!contents.empty() &&
+        !input.read(contents.data(), static_cast<std::streamsize>(contents.size())))) {
+        error = "cannot read text file";
+        return false;
+    }
+    return true;
+}
+
+std::string WrapHashBlock(std::string_view block) {
+    std::string output = "#usda 1.0\n(\n    upAxis = \"Z\"\n)\n\n"
+                         "over \"RootNode\"\n{\n    over \"Looks\"\n    {\n";
+    output.append(block.data(), block.size());
+    output += "\n    }\n}\n";
+    return output;
+}
+
+bool SplitLegacyLayer(const std::string& contents,
+                      std::map<std::string, std::string>& layers,
+                      std::string& error) {
+    if (contents.find("#usda 1.0") == std::string::npos ||
+        contents.find("over \"RootNode\"") == std::string::npos ||
+        contents.find("over \"Looks\"") == std::string::npos) {
+        error = "legacy profile layer is not an AdvMat USDA layer";
+        return false;
+    }
+
+    constexpr std::string_view marker = "over \"mat_";
+    std::size_t cursor = 0;
+    while ((cursor = contents.find(marker, cursor)) != std::string::npos) {
+        const auto hashStart = cursor + marker.size();
+        if (hashStart + 17 > contents.size() || contents[hashStart + 16] != '"') {
+            error = "legacy profile contains a malformed captured texture hash";
+            return false;
+        }
+        std::string canonical;
+        if (!CanonicalizeHash(contents.substr(hashStart, 16), canonical, error)) {
+            error = "legacy profile contains an invalid captured texture hash: " + error;
+            return false;
+        }
+
+        const auto open = contents.find('{', hashStart + 17);
+        if (open == std::string::npos) {
+            error = "legacy profile material block has no opening brace";
+            return false;
+        }
+        std::size_t depth = 0;
+        std::size_t close = std::string::npos;
+        bool inString = false;
+        bool inAsset = false;
+        bool escaped = false;
+        for (std::size_t index = open; index < contents.size(); ++index) {
+            const char character = contents[index];
+            if (inString) {
+                if (escaped) escaped = false;
+                else if (character == '\\') escaped = true;
+                else if (character == '"') inString = false;
+                continue;
+            }
+            if (inAsset) {
+                if (character == '@') inAsset = false;
+                continue;
+            }
+            if (character == '"') {
+                inString = true;
+            } else if (character == '@') {
+                inAsset = true;
+            } else if (character == '{') {
+                ++depth;
+            } else if (character == '}') {
+                if (depth == 0) {
+                    error = "legacy profile material block has unbalanced braces";
+                    return false;
+                }
+                --depth;
+                if (depth == 0) {
+                    close = index;
+                    break;
+                }
+            }
+        }
+        if (close == std::string::npos) {
+            error = "legacy profile material block has no closing brace";
+            return false;
+        }
+        const auto previousNewline = contents.rfind('\n', cursor);
+        const auto blockStart = previousNewline == std::string::npos ? 0 : previousNewline + 1;
+        if (!layers.emplace(canonical,
+                WrapHashBlock(std::string_view(contents).substr(blockStart, close - blockStart + 1))).second) {
+            error = "legacy profile contains a duplicate captured texture hash";
+            return false;
+        }
+        cursor = close + 1;
+    }
+    return true;
+}
+
+} // namespace
+
+Result Result::Success(std::string profileId) {
+    Result result;
+    result.ok = true;
+    result.code = "ok";
+    result.profileId = std::move(profileId);
+    return result;
+}
+
+Result Result::Failure(std::string code, std::string message) {
+    Result result;
+    result.ok = false;
+    result.code = std::move(code);
+    result.message = std::move(message);
+    return result;
+}
+
+bool ValidateProfileId(const std::string& value, std::string& error) {
+    if (value.empty() || value.size() > 64) {
+        error = "profile ID must contain 1 to 64 characters";
+        return false;
+    }
+    for (const unsigned char character : value) {
+        if (!(std::isalnum(character) || character == '_' || character == '-' || character == '.')) {
+            error = "profile ID may only contain ASCII letters, digits, underscore, hyphen and dot";
+            return false;
+        }
+    }
+    if (value == "." || value == ".." || value.front() == '.') {
+        error = "profile ID cannot be a dot path or begin with dot";
+        return false;
+    }
+    return true;
+}
+
+bool CanonicalizeHash(const std::string& value, std::string& canonical, std::string& error) {
+    std::size_t offset = 0;
+    if (value.size() >= 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X')) {
+        offset = 2;
+    }
+    const auto digits = value.size() - offset;
+    if (digits == 0 || digits > 16) {
+        error = "texture hash must contain 1 to 16 hexadecimal digits";
+        return false;
+    }
+    canonical.assign(16 - digits, '0');
+    bool nonzero = false;
+    for (std::size_t index = offset; index < value.size(); ++index) {
+        const unsigned char character = static_cast<unsigned char>(value[index]);
+        if (!std::isxdigit(character)) {
+            error = "texture hash contains a non-hexadecimal character";
+            canonical.clear();
+            return false;
+        }
+        const char upper = static_cast<char>(std::toupper(character));
+        canonical.push_back(upper);
+        nonzero = nonzero || upper != '0';
+    }
+    if (!nonzero) {
+        error = "zero is not a valid replacement texture hash";
+        canonical.clear();
+        return false;
+    }
+    return true;
+}
+
+bool ParseBridgeOperation(const std::string& value, BridgeOperation& operation,
+                          std::string& error) {
+    std::string normalized = value;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+        [](unsigned char character) { return static_cast<char>(std::tolower(character)); });
+    if (normalized.empty() || normalized == "commit") {
+        operation = BridgeOperation::Commit;
+        return true;
+    }
+    if (normalized == "preview") {
+        operation = BridgeOperation::Preview;
+        return true;
+    }
+    if (normalized == "restore") {
+        operation = BridgeOperation::Restore;
+        return true;
+    }
+    if (normalized == "clear") {
+        operation = BridgeOperation::Clear;
+        return true;
+    }
+    error = "request.operation is not supported";
+    return false;
+}
+
+std::optional<std::filesystem::path> FindGameRootFromExecutable(
+    const std::filesystem::path& executablePath) {
+    if (executablePath.empty() || !executablePath.is_absolute()) {
+        return std::nullopt;
+    }
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(executablePath, ec) || ec) {
+        return std::nullopt;
+    }
+
+    auto candidate = executablePath.parent_path();
+    for (std::size_t depth = 0; depth <= kMaxGameRootAncestorDepth; ++depth) {
+        ec.clear();
+        const bool hasGarrysMod = std::filesystem::is_directory(candidate / "garrysmod", ec);
+        if (!ec) {
+            const bool hasRemix = std::filesystem::is_directory(candidate / "rtx-remix", ec);
+            if (!ec && hasGarrysMod && hasRemix) {
+                return candidate.lexically_normal();
+            }
+        }
+        const auto parent = candidate.parent_path();
+        if (parent.empty() || parent == candidate) {
+            break;
+        }
+        candidate = parent;
+    }
+    return std::nullopt;
+}
+
+const char* TextureRoleName(TextureRole role) noexcept {
+    switch (role) {
+    case TextureRole::Albedo: return "albedo";
+    case TextureRole::Normal: return "normal";
+    case TextureRole::Anisotropy: return "anisotropy";
+    case TextureRole::Roughness: return "roughness";
+    case TextureRole::Metallic: return "metallic";
+    case TextureRole::Height: return "height";
+    case TextureRole::Emissive: return "emissive";
+    case TextureRole::SubsurfaceTransmittance: return "subsurface_transmittance";
+    case TextureRole::SubsurfaceThickness: return "subsurface_thickness";
+    case TextureRole::SubsurfaceScattering: return "subsurface_scattering";
+    case TextureRole::SubsurfaceRadius: return "subsurface_radius";
+    }
+    return "unknown";
+}
+
+namespace {
+
+bool IsHexString(std::string_view value) {
+    if (value.empty()) return false;
+    return std::all_of(value.begin(), value.end(), [](unsigned char character) {
+        return std::isxdigit(character) != 0;
+    });
+}
+
+std::optional<std::string> HashFromProfileId(const std::string& id) {
+    if (id.rfind("hash_", 0) != 0 || (id.size() != 21 && id.size() != 38)) {
+        return std::nullopt;
+    }
+    if (id.size() == 38 && (id[21] != '_' ||
+        !IsHexString(std::string_view(id).substr(22, 16)))) {
+        return std::nullopt;
+    }
+    std::string canonical;
+    std::string ignored;
+    if (!CanonicalizeHash(id.substr(5, 16), canonical, ignored)) {
+        return std::nullopt;
+    }
+    return canonical;
+}
+
+bool IsOwnedProfileId(const std::string& id) {
+    std::string ignored;
+    if (!ValidateProfileId(id, ignored)) return false;
+    if (id.rfind("material_", 0) == 0) {
+        return true;
+    }
+    return HashFromProfileId(id).has_value();
+}
+
+std::string ContentRevision(std::string_view contents) {
+    std::uint64_t hash = 14695981039346656037ull;
+    for (const unsigned char character : contents) {
+        hash ^= character;
+        hash *= 1099511628211ull;
+    }
+    std::ostringstream output;
+    output << std::uppercase << std::hex << std::setfill('0') << std::setw(16) << hash;
+    return output.str();
+}
+
+std::string VersionedProfileId(const std::string& hash, std::string_view contents) {
+    return "hash_" + hash + "_" + ContentRevision(contents);
+}
+
+void NormalizeProfiles(std::vector<std::string>& profiles) {
+    std::sort(profiles.begin(), profiles.end());
+    profiles.erase(std::unique(profiles.begin(), profiles.end()), profiles.end());
+}
+
+void RemoveHash(std::vector<std::string>& profiles, const std::string& hash) {
+    profiles.erase(std::remove_if(profiles.begin(), profiles.end(), [&hash](const std::string& id) {
+        const auto layerHash = HashFromProfileId(id);
+        return layerHash && *layerHash == hash;
+    }), profiles.end());
+}
+
+bool ParseModLayer(const std::string& contents, std::vector<std::string>& profiles,
+                   std::string& error) {
+    const auto declaration = contents.find("subLayers");
+    const auto open = declaration == std::string::npos ? std::string::npos :
+        contents.find('[', declaration);
+    const auto close = open == std::string::npos ? std::string::npos :
+        contents.find(']', open + 1);
+    if (open == std::string::npos || close == std::string::npos) {
+        error = "owned mod root has no valid subLayers array";
+        return false;
+    }
+
+    std::set<std::string> seen;
+    std::size_t cursor = open + 1;
+    while (true) {
+        const auto assetStart = contents.find('@', cursor);
+        if (assetStart == std::string::npos || assetStart >= close) break;
+        const auto assetEnd = contents.find('@', assetStart + 1);
+        if (assetEnd == std::string::npos || assetEnd > close) {
+            error = "owned mod root contains an unterminated sublayer asset";
+            return false;
+        }
+        const std::string asset = contents.substr(assetStart + 1,
+            assetEnd - assetStart - 1);
+        constexpr std::string_view prefix = "./profiles/";
+        constexpr std::string_view suffix = ".usda";
+        if (asset.size() <= prefix.size() + suffix.size() ||
+            asset.compare(0, prefix.size(), prefix) != 0 ||
+            asset.compare(asset.size() - suffix.size(), suffix.size(), suffix) != 0) {
+            error = "owned mod root references a layer outside profiles/";
+            return false;
+        }
+        const auto id = asset.substr(prefix.size(),
+            asset.size() - prefix.size() - suffix.size());
+        if (!IsOwnedProfileId(id) || !seen.insert(id).second) {
+            error = "owned mod root contains an invalid or duplicate profile layer";
+            return false;
+        }
+        profiles.push_back(id);
+        cursor = assetEnd + 1;
+    }
+    NormalizeProfiles(profiles);
+    return true;
+}
+
+bool IsOwnedTextureFileName(const std::string& filename) {
+    constexpr std::string_view suffix = ".dds";
+    // "tangent" is recognized only while tracing files referenced by an old
+    // on-disk layer so migration cleanup cannot delete its active dependency.
+    // The request parser and current writer do not expose that retired role.
+    static constexpr std::string_view roles[]{
+        "albedo", "normal", "anisotropy", "roughness",
+        "metallic", "height", "emissive", "subsurface_transmittance",
+        "subsurface_thickness", "subsurface_scattering", "subsurface_radius",
+        "tangent",
+    };
+    static_assert(std::size(roles) == kTextureRoleCount + 1);
+    if (filename.size() <= suffix.size() ||
+        filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return false;
+    }
+    for (const auto role : roles) {
+        const std::string prefix = std::string(role) + "_";
+        if (filename.size() == prefix.size() + 16 + suffix.size() &&
+            filename.compare(0, prefix.size(), prefix) == 0 &&
+            IsHexString(std::string_view(filename).substr(prefix.size(), 16))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CollectOwnedTextureReferences(
+        const std::string& contents, const std::filesystem::path& modDirectory,
+        std::vector<std::filesystem::path>& references, std::string& error) {
+    constexpr std::string_view prefix = "../textures/";
+    std::size_t cursor = 0;
+    while (true) {
+        const auto assetStart = contents.find('@', cursor);
+        if (assetStart == std::string::npos) break;
+        const auto assetEnd = contents.find('@', assetStart + 1);
+        if (assetEnd == std::string::npos) {
+            error = "active profile contains an unterminated asset path";
+            return false;
+        }
+        std::string asset = contents.substr(assetStart + 1, assetEnd - assetStart - 1);
+        std::replace(asset.begin(), asset.end(), '\\', '/');
+        cursor = assetEnd + 1;
+        if (asset.compare(0, prefix.size(), prefix) != 0) continue;
+
+        const std::filesystem::path relative(asset.substr(prefix.size()));
+        if (relative.empty() || relative.is_absolute()) {
+            error = "active profile contains an invalid owned texture asset";
+            return false;
+        }
+        std::vector<std::filesystem::path> components;
+        for (const auto& component : relative) {
+            if (component.empty() || component == "." || component == ".." ||
+                component.has_root_path()) {
+                error = "active profile contains an unsafe owned texture asset";
+                return false;
+            }
+            components.push_back(component);
+        }
+        if (components.size() != 2) {
+            error = "active profile contains an unexpected owned texture path shape";
+            return false;
+        }
+        std::string ignored;
+        if (!ValidateProfileId(components[0].string(), ignored) ||
+            !IsOwnedTextureFileName(components[1].string())) {
+            error = "active profile contains an invalid owned texture filename";
+            return false;
+        }
+        const auto absolute = (modDirectory / "textures" / relative).lexically_normal();
+        if (!detail::IsDescendantOrSame(absolute, modDirectory / "textures")) {
+            error = "active profile texture asset escaped the owned cache";
+            return false;
+        }
+        references.push_back(absolute);
+    }
+    return true;
+}
+
+} // namespace
+
+struct Bridge::Impl {
+    Config config;
+    std::filesystem::path modDirectory;
+    std::vector<std::filesystem::path> allowedRoots;
+    std::string initializationError;
+    mutable std::mutex mutex;
+
+    explicit Impl(Config incoming) : config(std::move(incoming)) {
+        std::error_code ec;
+        if (config.maxTextureBytes == 0 || config.maxTextureDimension == 0 ||
+            config.maxActiveProfiles < 128 || config.maxActiveTextureFiles == 0 ||
+            config.maxActiveTextureBytes == 0) {
+            initializationError = "native writer resource limits are invalid";
+            return;
+        }
+        if (config.gameRoot.empty()) {
+            initializationError = "game root is empty";
+            return;
+        }
+        auto root = std::filesystem::canonical(config.gameRoot, ec);
+        if (ec || !std::filesystem::is_directory(root, ec)) {
+            initializationError = "game root is not an existing directory";
+            return;
+        }
+        config.gameRoot = root;
+        std::string pathError;
+        bool pathExists = false;
+        const auto runtimeDirectory = root / "rtx-remix";
+        if (!detail::InspectPlainPath(runtimeDirectory, true, pathExists, pathError) ||
+            !pathExists) {
+            initializationError = "game root does not contain an rtx-remix runtime directory";
+            if (!pathError.empty()) initializationError += ": " + pathError;
+            return;
+        }
+        modDirectory = root / "rtx-remix" / "mods" / "!advanced_material_editor";
+        if (modDirectory.filename() != "!advanced_material_editor" ||
+            modDirectory.parent_path().filename() != "mods") {
+            initializationError = "internal mod destination invariant failed";
+            return;
+        }
+
+        // Do not create output during capability discovery, but reject every
+        // existing component/leaf which could redirect later reads or writes.
+        // Missing mods/addon directories are created one component at a time by
+        // EnsureModDirectory on the first commit.
+        const std::pair<std::filesystem::path, bool> ownedPaths[]{
+            {root / "rtx-remix" / "mods", true},
+            {modDirectory, true},
+            {modDirectory / "mod.usda", false},
+            {modDirectory / "profiles", true},
+            {modDirectory / "profiles.retired", true},
+            {modDirectory / "textures", true},
+            {modDirectory / "textures.retired", true},
+        };
+        for (const auto& [path, requireDirectory] : ownedPaths) {
+            pathError.clear();
+            if (!detail::InspectPlainPath(path, requireDirectory, pathExists, pathError)) {
+                initializationError = "unsafe existing native output path: " + pathError;
+                return;
+            }
+        }
+
+        if (config.allowedTextureRoots.empty()) {
+            allowedRoots.push_back(root);
+        } else {
+            for (const auto& configuredRoot : config.allowedTextureRoots) {
+                auto canonicalRoot = std::filesystem::canonical(configuredRoot, ec);
+                if (ec || !std::filesystem::is_directory(canonicalRoot, ec)) {
+                    initializationError = "an allowed texture root is not an existing directory";
+                    return;
+                }
+                // Import roots must themselves be below the game install. This
+                // prevents the Lua-facing API from becoming an arbitrary file reader.
+                if (!detail::IsDescendantOrSame(canonicalRoot, root)) {
+                    initializationError = "allowed texture roots must be inside the game root";
+                    return;
+                }
+                allowedRoots.push_back(std::move(canonicalRoot));
+            }
+        }
+    }
+
+    bool Injected(std::string_view point) const noexcept {
+        if (!config.failureInjector) return false;
+        try {
+            return config.failureInjector(point);
+        } catch (...) {
+            return true;
+        }
+    }
+
+    std::filesystem::path ProfilePath(const std::string& id) const {
+        return modDirectory / "profiles" / (id + ".usda");
+    }
+
+    bool InspectModDirectory(bool& exists, std::string& error) const {
+        exists = false;
+        bool componentExists = false;
+        const auto runtimeDirectory = config.gameRoot / "rtx-remix";
+        if (!detail::InspectPlainPath(runtimeDirectory, true, componentExists, error) ||
+            !componentExists) {
+            if (error.empty()) error = "rtx-remix runtime directory is missing";
+            return false;
+        }
+        const auto modsDirectory = runtimeDirectory / "mods";
+        if (!detail::InspectPlainPath(modsDirectory, true, componentExists, error)) return false;
+        if (!componentExists) return true;
+        if (!detail::InspectPlainPath(modDirectory, true, exists, error)) return false;
+        if (!exists) return true;
+        return detail::ValidatePlainDirectoryTree(config.gameRoot, modDirectory, error);
+    }
+
+    bool EnsureModDirectory(std::string& error) const {
+        bool runtimeExists = false;
+        if (!detail::InspectPlainPath(config.gameRoot / "rtx-remix", true,
+                                      runtimeExists, error) || !runtimeExists) {
+            if (error.empty()) error = "rtx-remix runtime directory is missing";
+            return false;
+        }
+        return detail::EnsurePlainDirectoryTree(config.gameRoot, modDirectory, error);
+    }
+
+    bool RetireOwnedDirectory(const char* activeName, const char* retiredName,
+                              bool& rotated, std::filesystem::path& retiredPath,
+                              std::string& error) const {
+        rotated = false;
+        const auto active = modDirectory / activeName;
+        const auto retired = modDirectory / retiredName;
+        if (!detail::IsDescendantOrSame(active, modDirectory) ||
+            !detail::IsDescendantOrSame(retired, modDirectory) ||
+            active.parent_path() != modDirectory || retired.parent_path() != modDirectory) {
+            error = "computed retirement path escaped the owned mod directory";
+            return false;
+        }
+        if (!detail::ValidatePlainDirectoryTree(config.gameRoot, modDirectory, error)) {
+            error = std::string("cannot validate retirement root: ") + error;
+            return false;
+        }
+
+        bool activeExists = false;
+        if (!detail::InspectPlainPath(active, true, activeExists, error)) {
+            error = std::string("cannot retire ") + activeName + ": " + error;
+            return false;
+        }
+        // An idempotent reset keeps the previous quarantine when no new
+        // generation exists. This bounds storage without discarding the sole
+        // inactive generation on every repeated reset call.
+        if (!activeExists) return true;
+
+        bool retiredExists = false;
+        if (!detail::InspectPlainPath(retired, true, retiredExists, error)) {
+            error = std::string("cannot replace ") + retiredName + ": " + error;
+            return false;
+        }
+        if (retiredExists) {
+            if (!detail::ValidatePlainDirectoryTree(config.gameRoot, modDirectory, error) ||
+                !detail::InspectPlainPath(retired, true, retiredExists, error) ||
+                !retiredExists) {
+                if (error.empty()) error = "retirement quarantine changed before cleanup";
+                return false;
+            }
+            // Validate every descendant too. A nested Win32 junction must not
+            // turn bounded quarantine replacement into deletion outside this
+            // addon's directory.
+            if (!detail::RemovePlainDirectoryTree(retired, error)) {
+                error = std::string("cannot remove prior ") + retiredName + ": " + error;
+                return false;
+            }
+        }
+
+        // Cleanup and rename are separate filesystem operations. Revalidate
+        // every ancestor and both leaves after cleanup and immediately before
+        // the contained same-directory move.
+        if (!detail::ValidatePlainDirectoryTree(config.gameRoot, modDirectory, error) ||
+            !detail::InspectPlainPath(active, true, activeExists, error) || !activeExists ||
+            !detail::InspectPlainPath(retired, true, retiredExists, error) || retiredExists) {
+            if (error.empty()) error = "retirement paths changed before rename";
+            return false;
+        }
+
+        if (!detail::AtomicReplacePath(active, retired, error)) {
+            error = std::string("cannot retire ") + activeName + ": " + error;
+            return false;
+        }
+        rotated = true;
+        retiredPath = retired;
+        return true;
+    }
+
+    bool LoadActiveProfiles(std::vector<std::string>& profiles,
+                            std::string& error) const {
+        bool modExists = false;
+        if (!InspectModDirectory(modExists, error)) return false;
+        if (!modExists) return true;
+        const auto modLayer = modDirectory / "mod.usda";
+        bool modLayerExists = false;
+        if (!detail::InspectPlainPath(modLayer, false, modLayerExists, error)) return false;
+        if (!modLayerExists) return true;
+        std::string contents;
+        if (!ReadTextFileBounded(modLayer, kMaximumLegacyLayerBytes, contents, error) ||
+            !ParseModLayer(contents, profiles, error)) {
+            return false;
+        }
+        if (profiles.size() > config.maxActiveProfiles) {
+            error = "owned mod root exceeds the active profile limit";
+            return false;
+        }
+        const auto profilesDirectory = modDirectory / "profiles";
+        bool profilesExist = false;
+        if (!detail::InspectPlainPath(profilesDirectory, true, profilesExist, error)) return false;
+        if (profilesExist &&
+            !detail::ValidatePlainDirectoryTree(config.gameRoot, profilesDirectory, error)) {
+            return false;
+        }
+        if (!profiles.empty() && !profilesExist) {
+            error = "owned mod root references profiles but profiles/ is missing";
+            return false;
+        }
+        for (const auto& id : profiles) {
+            bool profileExists = false;
+            if (!detail::InspectPlainPath(ProfilePath(id), false, profileExists, error) ||
+                !profileExists) {
+                error = "owned mod root references a missing profile layer: " + id;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool CollectActiveOwnedFiles(
+            const std::vector<std::string>& active,
+            std::vector<std::filesystem::path>& profiles,
+            std::vector<std::filesystem::path>& textures,
+            std::string& error) const {
+        bool modExists = false;
+        if (!InspectModDirectory(modExists, error)) return false;
+        if (!modExists) {
+            if (!active.empty()) error = "active profiles exist without an owned mod directory";
+            return active.empty();
+        }
+
+        profiles.clear();
+        textures.clear();
+        profiles.reserve(active.size());
+        for (const auto& id : active) {
+            const auto profile = ProfilePath(id);
+            bool profileExists = false;
+            if (!detail::InspectPlainPath(profile, false, profileExists, error) ||
+                !profileExists) {
+                if (error.empty()) error = "active profile disappeared during cache pruning";
+                return false;
+            }
+            std::string contents;
+            if (!ReadTextFileBounded(profile, kMaximumLegacyLayerBytes, contents, error) ||
+                !CollectOwnedTextureReferences(
+                    contents, modDirectory, textures, error)) {
+                return false;
+            }
+            profiles.push_back(profile);
+        }
+        std::sort(textures.begin(), textures.end());
+        textures.erase(std::unique(textures.begin(), textures.end()), textures.end());
+        return true;
+    }
+
+    bool ValidateActiveTextureQuota(const std::vector<std::string>& active,
+                                    std::string& error) const {
+        std::vector<std::filesystem::path> activeProfiles;
+        std::vector<std::filesystem::path> activeTextures;
+        if (!CollectActiveOwnedFiles(
+                active, activeProfiles, activeTextures, error)) {
+            return false;
+        }
+        if (activeTextures.size() > config.maxActiveTextureFiles) {
+            error = "prospective active texture set exceeds the file-count limit";
+            return false;
+        }
+        std::uintmax_t totalBytes = 0;
+        for (const auto& texture : activeTextures) {
+            bool exists = false;
+            if (!detail::InspectPlainPath(texture, false, exists, error) || !exists) {
+                if (error.empty()) error = "an active owned texture is missing";
+                return false;
+            }
+            std::error_code ec;
+            const auto size = std::filesystem::file_size(texture, ec);
+            if (ec) {
+                error = "cannot inspect active owned texture size: " + ec.message();
+                return false;
+            }
+            if (size > config.maxActiveTextureBytes - totalBytes) {
+                error = "prospective active texture set exceeds the byte limit";
+                return false;
+            }
+            totalBytes += size;
+        }
+        return true;
+    }
+
+    bool PruneInactiveOwnedFiles(const std::vector<std::string>& active,
+                                 std::string& error) const {
+        std::vector<std::filesystem::path> keepProfiles;
+        std::vector<std::filesystem::path> keepTextures;
+        if (!CollectActiveOwnedFiles(active, keepProfiles, keepTextures, error)) {
+            return false;
+        }
+
+        if (!detail::PrunePlainDirectoryTree(
+                modDirectory / "profiles", keepProfiles, error)) {
+            error = "cannot prune inactive profile revisions: " + error;
+            return false;
+        }
+        if (!detail::PrunePlainDirectoryTree(
+                modDirectory / "textures", keepTextures, error)) {
+            error = "cannot prune inactive texture revisions: " + error;
+            return false;
+        }
+        return true;
+    }
+
+    Result WriteModLast(std::vector<std::string> profiles,
+                        bool forcePublish = false) const {
+        std::string error;
+        const auto modLayer = modDirectory / "mod.usda";
+        NormalizeProfiles(profiles);
+        if (profiles.size() > config.maxActiveProfiles) {
+            return Result::Failure("resource_limit",
+                "prospective root exceeds the active profile limit");
+        }
+        const auto contents = detail::BuildModLayer(profiles);
+        if (contents.size() > kMaximumLegacyLayerBytes) {
+            return Result::Failure("resource_limit",
+                "prospective root layer exceeds the byte limit");
+        }
+        if (!EnsureModDirectory(error)) {
+            return Result::Failure("mod_index_write_failed", error);
+        }
+        bool modLayerExists = false;
+        if (!detail::InspectPlainPath(modLayer, false, modLayerExists, error)) {
+            return Result::Failure("mod_index_write_failed", error);
+        }
+        if (!forcePublish && TextFileEquals(modLayer, contents)) {
+            return Result::Success();
+        }
+        if (!EnsureModDirectory(error) ||
+            !detail::InspectPlainPath(modLayer, false, modLayerExists, error)) {
+            return Result::Failure("mod_index_write_failed", error);
+        }
+        if (!detail::AtomicWriteText(modLayer, contents, error)) {
+            return Result::Failure("mod_index_write_failed", error);
+        }
+        // The staging file already has a fresh timestamp. Avoid a second,
+        // non-transactional metadata mutation after the root commit point.
+        return Result::Success();
+    }
+
+    bool StageImmutableProfile(const std::string& id, const std::string& contents,
+                               std::filesystem::path& path, std::string& error) const {
+        if (!IsOwnedProfileId(id)) {
+            error = "computed immutable profile ID is invalid";
+            return false;
+        }
+        path = ProfilePath(id);
+        if (!detail::IsDescendantOrSame(path, modDirectory)) {
+            error = "computed immutable profile path escaped the mod directory";
+            return false;
+        }
+        const auto profilesDirectory = modDirectory / "profiles";
+        if (!EnsureModDirectory(error) ||
+            !detail::EnsurePlainDirectoryTree(config.gameRoot, profilesDirectory, error)) {
+            return false;
+        }
+        bool pathExists = false;
+        if (!detail::InspectPlainPath(path, false, pathExists, error)) return false;
+        if (pathExists) {
+            if (!TextFileEquals(path, contents)) {
+                error = "immutable profile revision collision or corruption";
+                return false;
+            }
+            return true;
+        }
+        if (!detail::ValidatePlainDirectoryTree(config.gameRoot, profilesDirectory, error) ||
+            !detail::InspectPlainPath(path, false, pathExists, error)) return false;
+        if (pathExists) {
+            if (!TextFileEquals(path, contents)) {
+                error = "immutable profile revision collision or corruption";
+                return false;
+            }
+            return true;
+        }
+        if (!detail::AtomicWriteText(path, contents, error)) {
+            return false;
+        }
+        return true;
+    }
+
+    bool StageLegacyMigration(const std::string& profileId,
+                              std::vector<std::string>& active,
+                              std::string& error) const {
+        if (profileId.rfind("material_", 0) != 0 ||
+            std::find(active.begin(), active.end(), profileId) == active.end()) {
+            return true;
+        }
+        const auto legacy = ProfilePath(profileId);
+        bool legacyExists = false;
+        if (!detail::ValidatePlainDirectoryTree(config.gameRoot,
+                modDirectory / "profiles", error) ||
+            !detail::InspectPlainPath(legacy, false, legacyExists, error) ||
+            !legacyExists) {
+            if (error.empty()) error = "active legacy profile layer is missing";
+            return false;
+        }
+        std::string contents;
+        if (!ReadTextFileBounded(legacy, kMaximumLegacyLayerBytes, contents, error)) {
+            return false;
+        }
+        std::map<std::string, std::string> split;
+        if (!SplitLegacyLayer(contents, split, error)) {
+            return false;
+        }
+        std::vector<std::pair<std::string, std::string>> revisions;
+        revisions.reserve(split.size());
+        std::vector<std::string> migratedActive = active;
+        migratedActive.erase(
+            std::remove(migratedActive.begin(), migratedActive.end(), profileId),
+            migratedActive.end());
+        for (const auto& [hash, layerContents] : split) {
+            const auto id = VersionedProfileId(hash, layerContents);
+            RemoveHash(migratedActive, hash);
+            migratedActive.push_back(id);
+            revisions.emplace_back(id, layerContents);
+        }
+        NormalizeProfiles(migratedActive);
+        if (migratedActive.size() > config.maxActiveProfiles) {
+            error = "legacy migration exceeds the active profile limit";
+            return false;
+        }
+        for (const auto& [id, layerContents] : revisions) {
+            std::filesystem::path path;
+            if (!StageImmutableProfile(id, layerContents, path, error)) {
+                error = "cannot stage migrated profile " + id + ": " + error;
+                return false;
+            }
+        }
+        active = std::move(migratedActive);
+        return true;
+    }
+};
+
+Bridge::Bridge(Config config) : impl_(new Impl(std::move(config))) {}
+Bridge::~Bridge() { delete impl_; }
+Bridge::Bridge(Bridge&& other) noexcept : impl_(std::exchange(other.impl_, nullptr)) {}
+Bridge& Bridge::operator=(Bridge&& other) noexcept {
+    if (this != &other) {
+        delete impl_;
+        impl_ = std::exchange(other.impl_, nullptr);
+    }
+    return *this;
+}
+
+const std::filesystem::path& Bridge::ModDirectory() const noexcept {
+    static const std::filesystem::path empty;
+    return impl_ ? impl_->modDirectory : empty;
+}
+
+Capabilities Bridge::GetCapabilities() const {
+    Capabilities capabilities;
+    if (impl_) {
+        capabilities.modDirectory = impl_->modDirectory;
+        capabilities.available = impl_->initializationError.empty();
+    } else {
+        capabilities.available = false;
+    }
+    capabilities.wicImageConversion = detail::SupportsWicConversion();
+    capabilities.textureOperations = detail::SupportsTextureOperations();
+    if (impl_) {
+        capabilities.maxTextureBytes = impl_->config.maxTextureBytes;
+        capabilities.maxTextureDimension = impl_->config.maxTextureDimension;
+        capabilities.maxActiveProfiles = impl_->config.maxActiveProfiles;
+        capabilities.maxActiveTextureFiles = impl_->config.maxActiveTextureFiles;
+        capabilities.maxActiveTextureBytes = impl_->config.maxActiveTextureBytes;
+    }
+    return capabilities;
+}
+
+Result Bridge::ApplyLegacyMaterial(const ApplyRequest& request) {
+    if (request.operation == BridgeOperation::Preview) {
+        return Result::Failure("preview_unsupported",
+            "protocol 1 cannot provide reversible live preview without publishing persistent USDA state");
+    }
+    if (request.operation != BridgeOperation::Commit) {
+        return Result::Failure("invalid_apply_operation",
+            "restore and clear operations must use ClearLegacyMaterial");
+    }
+    if (!impl_ || !impl_->initializationError.empty()) {
+        return Result::Failure("not_initialized", impl_ ? impl_->initializationError : "bridge was moved from");
+    }
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    std::string error;
+    if (!ValidateProfileId(request.profileId, error)) {
+        return Result::Failure("invalid_profile_id", error);
+    }
+    if (request.hashes.empty() || request.hashes.size() > 128) {
+        return Result::Failure("invalid_hash_count", "one to 128 texture hashes are required");
+    }
+    if (!detail::ValidateMaterial(request.material, error)) {
+        return Result::Failure("invalid_material", error);
+    }
+
+    std::vector<std::string> hashes;
+    hashes.reserve(request.hashes.size());
+    for (const auto& input : request.hashes) {
+        std::string canonical;
+        if (!CanonicalizeHash(input, canonical, error)) {
+            return Result::Failure("invalid_hash", error);
+        }
+        hashes.push_back(std::move(canonical));
+    }
+    std::sort(hashes.begin(), hashes.end());
+    hashes.erase(std::unique(hashes.begin(), hashes.end()), hashes.end());
+
+    std::vector<std::string> active;
+    if (!impl_->LoadActiveProfiles(active, error)) {
+        return Result::Failure("mod_index_read_failed", error);
+    }
+    if (!impl_->PruneInactiveOwnedFiles(active, error)) {
+        return Result::Failure("owned_cache_cleanup_failed", error);
+    }
+    const auto failAndClean = [this, &active](Result failure) {
+        std::string cleanupError;
+        if (!impl_->PruneInactiveOwnedFiles(active, cleanupError)) {
+            if (!failure.message.empty()) failure.message += "; ";
+            failure.message += "transaction cleanup also failed: " + cleanupError;
+        }
+        return failure;
+    };
+
+    std::vector<std::string> nextActive = active;
+    if (!impl_->StageLegacyMigration(request.profileId, nextActive, error)) {
+        return failAndClean(Result::Failure("legacy_profile_migration_failed", error));
+    }
+    for (const auto& hash : hashes) {
+        RemoveHash(nextActive, hash);
+    }
+    NormalizeProfiles(nextActive);
+    if (nextActive.size() > impl_->config.maxActiveProfiles ||
+        hashes.size() > impl_->config.maxActiveProfiles - nextActive.size()) {
+        return failAndClean(Result::Failure("resource_limit",
+            "prospective replacement set exceeds the active profile limit"));
+    }
+
+    std::vector<detail::ImportedTexture> imported;
+    imported.reserve(request.material.textures.size());
+    detail::TextureImportConfig textureConfig{
+        impl_->config.gameRoot, impl_->modDirectory, impl_->allowedRoots, impl_->config.maxTextureBytes,
+        impl_->config.maxTextureDimension};
+    for (const auto& texture : request.material.textures) {
+        detail::ImportedTexture result;
+        auto status = detail::ImportTexture(textureConfig, request.profileId, texture, result);
+        if (!status.ok) {
+            return failAndClean(std::move(status));
+        }
+        imported.push_back(std::move(result));
+    }
+    std::sort(imported.begin(), imported.end(), [](const auto& left, const auto& right) {
+        return static_cast<int>(left.role) < static_cast<int>(right.role);
+    });
+
+    std::vector<std::filesystem::path> layers;
+    layers.reserve(hashes.size());
+    for (const auto& hash : hashes) {
+        const auto layerContents = detail::BuildProfileLayer({hash}, request.material, imported);
+        const auto id = VersionedProfileId(hash, layerContents);
+        std::filesystem::path layer;
+        if (!impl_->StageImmutableProfile(id, layerContents, layer, error)) {
+            return failAndClean(Result::Failure("profile_stage_failed", error));
+        }
+        if (impl_->Injected("apply_after_stage_layer")) {
+            return failAndClean(Result::Failure("injected_failure",
+                "test failure injected after staging an immutable profile layer"));
+        }
+        RemoveHash(nextActive, hash);
+        nextActive.push_back(id);
+        layers.push_back(layer);
+    }
+    NormalizeProfiles(nextActive);
+    if (!impl_->ValidateActiveTextureQuota(nextActive, error)) {
+        return failAndClean(Result::Failure("resource_limit", error));
+    }
+
+    const bool textureChanged = std::any_of(imported.begin(), imported.end(),
+        [](const detail::ImportedTexture& texture) { return texture.changed; });
+    if (impl_->Injected("apply_before_root_publish")) {
+        return failAndClean(Result::Failure("injected_failure",
+            "test failure injected before the transactional root publication"));
+    }
+    auto modStatus = impl_->WriteModLast(nextActive, textureChanged);
+    if (!modStatus.ok) {
+        return failAndClean(std::move(modStatus));
+    }
+    auto result = Result::Success(request.profileId);
+    result.layerPaths = layers;
+    if (!layers.empty()) result.layerPath = layers.front();
+    for (const auto& texture : imported) {
+        result.importedTextures.push_back(texture.absolutePath);
+    }
+    return result;
+}
+
+Result Bridge::ClearLegacyMaterial(const ClearRequest& request) {
+    if (!impl_ || !impl_->initializationError.empty()) {
+        return Result::Failure("not_initialized", impl_ ? impl_->initializationError : "bridge was moved from");
+    }
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    std::string error;
+    if (!ValidateProfileId(request.profileId, error)) {
+        return Result::Failure("invalid_profile_id", error);
+    }
+    if (request.hashes.empty() || request.hashes.size() > 128) {
+        return Result::Failure("invalid_hash_count",
+            "one to 128 exact texture hashes are required for clear");
+    }
+
+    std::vector<std::string> hashes;
+    hashes.reserve(request.hashes.size());
+    for (const auto& input : request.hashes) {
+        std::string canonical;
+        if (!CanonicalizeHash(input, canonical, error)) {
+            return Result::Failure("invalid_hash", error);
+        }
+        hashes.push_back(std::move(canonical));
+    }
+    std::sort(hashes.begin(), hashes.end());
+    hashes.erase(std::unique(hashes.begin(), hashes.end()), hashes.end());
+
+    std::vector<std::string> active;
+    if (!impl_->LoadActiveProfiles(active, error)) {
+        return Result::Failure("mod_index_read_failed", error);
+    }
+    if (!impl_->PruneInactiveOwnedFiles(active, error)) {
+        return Result::Failure("owned_cache_cleanup_failed", error);
+    }
+    const auto previousActive = active;
+    const auto failAndClean = [this, &previousActive](Result failure) {
+        std::string cleanupError;
+        if (!impl_->PruneInactiveOwnedFiles(previousActive, cleanupError)) {
+            if (!failure.message.empty()) failure.message += "; ";
+            failure.message += "transaction cleanup also failed: " + cleanupError;
+        }
+        return failure;
+    };
+    if (!impl_->StageLegacyMigration(request.profileId, active, error)) {
+        return failAndClean(Result::Failure("legacy_profile_migration_failed", error));
+    }
+
+    auto result = Result::Success(request.profileId);
+    for (const auto& hash : hashes) {
+        for (const auto& id : active) {
+            const auto layerHash = HashFromProfileId(id);
+            if (layerHash && *layerHash == hash) {
+                result.layerPaths.push_back(impl_->ProfilePath(id));
+            }
+        }
+        RemoveHash(active, hash);
+    }
+    NormalizeProfiles(active);
+
+    if (impl_->Injected("clear_before_root_publish")) {
+        return failAndClean(Result::Failure("injected_failure",
+            "test failure injected before the exact-hash root publication"));
+    }
+    auto modStatus = impl_->WriteModLast(active);
+    if (!modStatus.ok) {
+        return failAndClean(std::move(modStatus));
+    }
+    if (!result.layerPaths.empty()) result.layerPath = result.layerPaths.front();
+    return result;
+}
+
+Result Bridge::ClearAllOwned() {
+    if (!impl_ || !impl_->initializationError.empty()) {
+        return Result::Failure("not_initialized",
+            impl_ ? impl_->initializationError : "bridge was moved from");
+    }
+    std::lock_guard<std::mutex> lock(impl_->mutex);
+
+    if (impl_->Injected("reset_before_root_publish")) {
+        return Result::Failure("injected_failure",
+            "test failure injected before the empty root publication");
+    }
+    // The empty root is the O(1) deactivation commit point. Never walk or
+    // mutate individual layers before it has been atomically published.
+    auto modStatus = impl_->WriteModLast({});
+    if (!modStatus.ok) {
+        return modStatus;
+    }
+    if (impl_->Injected("reset_after_root_publish")) {
+        return Result::Failure("injected_failure_after_commit",
+            "test failure injected after empty root publication and before retirement");
+    }
+
+    auto result = Result::Success();
+    std::string error;
+    bool profilesRotated = false;
+    std::filesystem::path retiredProfiles;
+    if (!impl_->RetireOwnedDirectory("profiles", "profiles.retired",
+                                     profilesRotated, retiredProfiles, error)) {
+        return Result::Failure("authoritative_reset_retire_failed_after_commit", error);
+    }
+    if (profilesRotated) {
+        result.layerPath = retiredProfiles;
+        result.layerPaths.push_back(retiredProfiles);
+    }
+    if (profilesRotated && impl_->Injected("reset_after_profile_retire")) {
+        return Result::Failure("injected_failure_after_commit",
+            "test failure injected after profile retirement and before texture retirement");
+    }
+
+    // Imported DDS names are immutable/content-addressed too. Rotate the whole
+    // cache only after the empty activation root is durable, and keep one fixed
+    // quarantine generation. Crucially this runs even when profiles/ was
+    // already retired by a prior failed attempt, making the two-step reset
+    // independently retryable after a crash.
+    bool texturesRotated = false;
+    std::filesystem::path retiredTextures;
+    if (!impl_->RetireOwnedDirectory("textures", "textures.retired",
+                                     texturesRotated, retiredTextures, error)) {
+        return Result::Failure("authoritative_reset_retire_failed_after_commit", error);
+    }
+    return result;
+}
+
+} // namespace advmat::rtx_bridge

--- a/source/advmat_rtx_bridge/src/filesystem_utils.cpp
+++ b/source/advmat_rtx_bridge/src/filesystem_utils.cpp
@@ -1,0 +1,535 @@
+#include "internal.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cwctype>
+#include <chrono>
+#include <fstream>
+#include <system_error>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace advmat::rtx_bridge::detail {
+namespace {
+
+std::atomic<std::uint64_t> g_tempCounter{0};
+
+std::uint64_t ProcessId() noexcept {
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(GetCurrentProcessId());
+#else
+    return static_cast<std::uint64_t>(getpid());
+#endif
+}
+
+bool FlushFileToDisk(const std::filesystem::path& path, std::string& error) {
+#ifdef _WIN32
+    const HANDLE handle = CreateFileW(path.c_str(), GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+        error = "CreateFileW for durable staging failed with Win32 error " +
+            std::to_string(GetLastError());
+        return false;
+    }
+    const bool flushed = FlushFileBuffers(handle) != FALSE;
+    const DWORD flushError = flushed ? ERROR_SUCCESS : GetLastError();
+    CloseHandle(handle);
+    if (!flushed) {
+        error = "FlushFileBuffers failed with Win32 error " +
+            std::to_string(flushError);
+        return false;
+    }
+#else
+    const int descriptor = open(path.c_str(), O_RDONLY);
+    if (descriptor < 0) {
+        error = "cannot open staging file for durable flush";
+        return false;
+    }
+    const bool flushed = fsync(descriptor) == 0;
+    close(descriptor);
+    if (!flushed) {
+        error = "fsync failed for staging file";
+        return false;
+    }
+#endif
+    return true;
+}
+
+} // namespace
+
+bool IsDescendantOrSame(const std::filesystem::path& candidate,
+                        const std::filesystem::path& root) {
+    const auto normalizedCandidate = candidate.lexically_normal();
+    const auto normalizedRoot = root.lexically_normal();
+    auto candidateIt = normalizedCandidate.begin();
+    auto rootIt = normalizedRoot.begin();
+    for (; rootIt != normalizedRoot.end(); ++rootIt, ++candidateIt) {
+        if (candidateIt == normalizedCandidate.end()) {
+            return false;
+        }
+#ifdef _WIN32
+        auto candidatePart = candidateIt->wstring();
+        auto rootPart = rootIt->wstring();
+        std::transform(candidatePart.begin(), candidatePart.end(), candidatePart.begin(),
+                       [](wchar_t character) { return std::towlower(character); });
+        std::transform(rootPart.begin(), rootPart.end(), rootPart.begin(),
+                       [](wchar_t character) { return std::towlower(character); });
+        if (candidatePart != rootPart) return false;
+#else
+        if (*candidateIt != *rootIt) return false;
+#endif
+    }
+    return true;
+}
+
+bool InspectPlainPath(const std::filesystem::path& path, bool requireDirectory,
+                      bool& exists, std::string& error) {
+    exists = false;
+    std::error_code ec;
+    const auto status = std::filesystem::symlink_status(path, ec);
+    if (ec) {
+        if (ec == std::errc::no_such_file_or_directory) return true;
+        error = "cannot inspect owned path: " + ec.message();
+        return false;
+    }
+    if (!std::filesystem::exists(status)) return true;
+    if (std::filesystem::is_symlink(status)) {
+        error = "owned path is a symbolic link or reparse point";
+        return false;
+    }
+#ifdef _WIN32
+    // MSVC's filesystem status has varied in how it reports junctions. The
+    // native attribute closes that gap for every existing destination
+    // component and leaf, not just the final quarantine directory.
+    const DWORD attributes = GetFileAttributesW(path.c_str());
+    if (attributes == INVALID_FILE_ATTRIBUTES) {
+        error = "cannot inspect owned path attributes (Win32 error " +
+            std::to_string(GetLastError()) + ")";
+        return false;
+    }
+    if ((attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+        error = "owned path is a symbolic link or reparse point";
+        return false;
+    }
+#endif
+    if (requireDirectory ? !std::filesystem::is_directory(status) :
+                           !std::filesystem::is_regular_file(status)) {
+        error = requireDirectory ? "owned path is not a directory" :
+                                   "owned path is not a regular file";
+        return false;
+    }
+    exists = true;
+    return true;
+}
+
+namespace {
+
+bool PlainDirectoryTree(const std::filesystem::path& root,
+                        const std::filesystem::path& directory,
+                        bool createMissing, std::string& error) {
+    const auto normalizedRoot = root.lexically_normal();
+    const auto normalizedDirectory = directory.lexically_normal();
+    if (normalizedRoot.empty() || normalizedDirectory.empty() ||
+        !normalizedRoot.is_absolute() || !normalizedDirectory.is_absolute() ||
+        !IsDescendantOrSame(normalizedDirectory, normalizedRoot)) {
+        error = "owned directory is outside the validated filesystem root";
+        return false;
+    }
+
+    bool rootExists = false;
+    if (!InspectPlainPath(normalizedRoot, true, rootExists, error) || !rootExists) {
+        if (error.empty()) error = "validated filesystem root is missing";
+        return false;
+    }
+
+    std::vector<std::filesystem::path> components;
+    auto current = normalizedRoot;
+    const auto relative = normalizedDirectory.lexically_relative(normalizedRoot);
+    if (relative.empty() && normalizedDirectory != normalizedRoot) {
+        error = "owned directory cannot be made relative to the validated root";
+        return false;
+    }
+    for (const auto& part : relative) {
+        if (part.empty() || part == ".") continue;
+        if (part == ".." || part.has_root_path()) {
+            error = "owned directory contains an unsafe path component";
+            return false;
+        }
+        current /= part;
+        components.push_back(current);
+
+        bool exists = false;
+        if (!InspectPlainPath(current, true, exists, error)) return false;
+        if (!exists) {
+            if (!createMissing) {
+                error = "owned directory component is missing";
+                return false;
+            }
+            std::error_code ec;
+            // Create exactly one component. If another actor wins the race,
+            // reinspection below accepts only a real non-reparse directory.
+            std::filesystem::create_directory(current, ec);
+            if (ec && ec != std::errc::file_exists) {
+                error = "cannot create owned directory component: " + ec.message();
+                return false;
+            }
+            if (!InspectPlainPath(current, true, exists, error) || !exists) {
+                if (error.empty()) error = "created owned directory component is missing";
+                return false;
+            }
+        }
+    }
+
+    // Revalidate the complete chain after the final creation. Callers invoke
+    // this again immediately before writes/renames, narrowing replacement races
+    // without ever trusting create_directories through an existing junction.
+    for (const auto& component : components) {
+        bool exists = false;
+        if (!InspectPlainPath(component, true, exists, error) || !exists) {
+            if (error.empty()) error = "owned directory component disappeared";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RemovePlainDirectoryTreeRecursive(const std::filesystem::path& directory,
+                                       std::string& error) {
+    bool directoryExists = false;
+    if (!InspectPlainPath(directory, true, directoryExists, error)) return false;
+    if (!directoryExists) return true;
+
+    // Do not hand a whole tree to remove_all: on Windows, a junction nested
+    // below an otherwise ordinary directory has historically been reported as
+    // a directory by some filesystem implementations. Enumerate without the
+    // follow-symlink option and validate every child's native attributes before
+    // either descending or deleting it.
+    std::vector<std::filesystem::path> children;
+    std::error_code ec;
+    std::filesystem::directory_iterator iterator(
+        directory, std::filesystem::directory_options::none, ec);
+    const std::filesystem::directory_iterator end;
+    if (ec) {
+        error = "cannot enumerate retirement directory: " + ec.message();
+        return false;
+    }
+    for (; iterator != end; iterator.increment(ec)) {
+        if (ec) {
+            error = "cannot enumerate retirement directory: " + ec.message();
+            return false;
+        }
+        children.push_back(iterator->path());
+    }
+    if (ec) {
+        error = "cannot enumerate retirement directory: " + ec.message();
+        return false;
+    }
+
+    for (const auto& child : children) {
+        const auto status = std::filesystem::symlink_status(child, ec);
+        if (ec) {
+            if (ec == std::errc::no_such_file_or_directory) {
+                ec.clear();
+                continue;
+            }
+            error = "cannot inspect retirement entry: " + ec.message();
+            return false;
+        }
+        if (!std::filesystem::exists(status)) continue;
+        if (std::filesystem::is_symlink(status)) {
+            error = "retirement tree contains a symbolic link or reparse point";
+            return false;
+        }
+        if (std::filesystem::is_directory(status)) {
+            if (!RemovePlainDirectoryTreeRecursive(child, error)) return false;
+            continue;
+        }
+        if (!std::filesystem::is_regular_file(status)) {
+            error = "retirement tree contains a non-regular filesystem entry";
+            return false;
+        }
+
+        bool childExists = false;
+        if (!InspectPlainPath(child, false, childExists, error)) return false;
+        if (!childExists) continue;
+        std::filesystem::remove(child, ec);
+        if (ec) {
+            error = "cannot remove retired file: " + ec.message();
+            return false;
+        }
+    }
+
+    // A raced-in child makes this fail closed with directory-not-empty. A
+    // raced-in reparse point is removed as a link by remove rather than walked;
+    // the target is never recursively traversed by this routine.
+    if (!InspectPlainPath(directory, true, directoryExists, error)) return false;
+    if (!directoryExists) return true;
+    std::filesystem::remove(directory, ec);
+    if (ec) {
+        error = "cannot remove retired directory: " + ec.message();
+        return false;
+    }
+    return true;
+}
+
+bool SameOwnedPath(const std::filesystem::path& left,
+                   const std::filesystem::path& right) {
+    return IsDescendantOrSame(left, right) && IsDescendantOrSame(right, left);
+}
+
+std::filesystem::path OwnedPathKey(const std::filesystem::path& path) {
+    auto normalized = path.lexically_normal();
+#ifdef _WIN32
+    auto native = normalized.native();
+    std::transform(native.begin(), native.end(), native.begin(),
+                   [](wchar_t character) { return std::towlower(character); });
+    normalized = std::filesystem::path(native);
+#endif
+    return normalized;
+}
+
+bool PrunePlainDirectoryTreeRecursive(
+        const std::filesystem::path& directory,
+        const std::vector<std::filesystem::path>& keepKeys,
+        bool removeWhenEmpty, bool& remains, std::string& error) {
+    remains = false;
+    bool directoryExists = false;
+    if (!InspectPlainPath(directory, true, directoryExists, error)) return false;
+    if (!directoryExists) return true;
+
+    std::vector<std::filesystem::path> children;
+    std::error_code ec;
+    std::filesystem::directory_iterator iterator(
+        directory, std::filesystem::directory_options::none, ec);
+    const std::filesystem::directory_iterator end;
+    if (ec) {
+        error = "cannot enumerate owned cache directory: " + ec.message();
+        return false;
+    }
+    for (; iterator != end; iterator.increment(ec)) {
+        if (ec) {
+            error = "cannot enumerate owned cache directory: " + ec.message();
+            return false;
+        }
+        children.push_back(iterator->path());
+    }
+    if (ec) {
+        error = "cannot enumerate owned cache directory: " + ec.message();
+        return false;
+    }
+
+    bool hasRemainingChild = false;
+    for (const auto& child : children) {
+        const auto status = std::filesystem::symlink_status(child, ec);
+        if (ec) {
+            if (ec == std::errc::no_such_file_or_directory) {
+                ec.clear();
+                continue;
+            }
+            error = "cannot inspect owned cache entry: " + ec.message();
+            return false;
+        }
+        if (!std::filesystem::exists(status)) continue;
+        if (std::filesystem::is_symlink(status)) {
+            error = "owned cache tree contains a symbolic link or reparse point";
+            return false;
+        }
+        if (std::filesystem::is_directory(status)) {
+            bool childRemains = false;
+            if (!PrunePlainDirectoryTreeRecursive(
+                    child, keepKeys, true, childRemains, error)) {
+                return false;
+            }
+            hasRemainingChild = hasRemainingChild || childRemains;
+            continue;
+        }
+        if (!std::filesystem::is_regular_file(status)) {
+            error = "owned cache tree contains a non-regular filesystem entry";
+            return false;
+        }
+
+        bool childExists = false;
+        if (!InspectPlainPath(child, false, childExists, error)) return false;
+        if (!childExists) continue;
+        const bool keep = std::binary_search(
+            keepKeys.begin(), keepKeys.end(), OwnedPathKey(child));
+        if (keep) {
+            hasRemainingChild = true;
+            continue;
+        }
+        std::filesystem::remove(child, ec);
+        if (ec) {
+            error = "cannot remove inactive owned cache file: " + ec.message();
+            return false;
+        }
+    }
+
+    if (!removeWhenEmpty || hasRemainingChild) {
+        remains = true;
+        return true;
+    }
+    if (!InspectPlainPath(directory, true, directoryExists, error)) return false;
+    if (!directoryExists) return true;
+    std::filesystem::remove(directory, ec);
+    if (ec) {
+        error = "cannot remove empty owned cache directory: " + ec.message();
+        return false;
+    }
+    if (!std::filesystem::exists(directory, ec) && !ec) return true;
+    if (ec) {
+        error = "cannot verify owned cache directory removal: " + ec.message();
+        return false;
+    }
+    error = "owned cache directory changed during pruning";
+    return false;
+}
+
+} // namespace
+
+bool ValidatePlainDirectoryTree(const std::filesystem::path& root,
+                                const std::filesystem::path& directory,
+                                std::string& error) {
+    return PlainDirectoryTree(root, directory, false, error);
+}
+
+bool EnsurePlainDirectoryTree(const std::filesystem::path& root,
+                              const std::filesystem::path& directory,
+                              std::string& error) {
+    return PlainDirectoryTree(root, directory, true, error);
+}
+
+bool RemovePlainDirectoryTree(const std::filesystem::path& directory,
+                              std::string& error) {
+    return RemovePlainDirectoryTreeRecursive(directory, error);
+}
+
+bool PrunePlainDirectoryTree(const std::filesystem::path& directory,
+                             const std::vector<std::filesystem::path>& keepFiles,
+                             std::string& error) {
+    std::vector<std::filesystem::path> keepKeys;
+    keepKeys.reserve(keepFiles.size());
+    for (const auto& keep : keepFiles) {
+        if (SameOwnedPath(keep, directory) || !IsDescendantOrSame(keep, directory)) {
+            error = "owned cache keep path escaped its directory";
+            return false;
+        }
+        keepKeys.push_back(OwnedPathKey(keep));
+    }
+    std::sort(keepKeys.begin(), keepKeys.end());
+    keepKeys.erase(std::unique(keepKeys.begin(), keepKeys.end()), keepKeys.end());
+    bool remains = false;
+    return PrunePlainDirectoryTreeRecursive(
+        directory, keepKeys, false, remains, error);
+}
+
+std::filesystem::path MakeTemporarySibling(const std::filesystem::path& destination) {
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto sequence = g_tempCounter.fetch_add(1, std::memory_order_relaxed);
+    return destination.parent_path() /
+        (destination.filename().string() + ".tmp." + std::to_string(ProcessId()) + "." +
+         std::to_string(now) + "." + std::to_string(sequence));
+}
+
+bool AtomicReplacePath(const std::filesystem::path& source,
+                       const std::filesystem::path& destination,
+                       std::string& error) {
+#ifdef _WIN32
+    if (!MoveFileExW(source.c_str(), destination.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        error = "MoveFileExW failed with Win32 error " + std::to_string(GetLastError());
+        return false;
+    }
+#else
+    std::error_code ec;
+    std::filesystem::rename(source, destination, ec);
+    if (ec) {
+        error = ec.message();
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool AtomicWriteBytes(const std::filesystem::path& destination,
+                      const std::vector<std::uint8_t>& contents,
+                      std::string& error) {
+    bool parentExists = false;
+    if (!InspectPlainPath(destination.parent_path(), true, parentExists, error) ||
+        !parentExists) {
+        if (error.empty()) error = "destination directory is missing";
+        return false;
+    }
+    bool destinationExists = false;
+    if (!InspectPlainPath(destination, false, destinationExists, error)) {
+        return false;
+    }
+
+    const auto staging = MakeTemporarySibling(destination);
+    bool stagingExists = false;
+    if (!InspectPlainPath(staging, false, stagingExists, error)) return false;
+    if (stagingExists) {
+        error = "staging path collision";
+        return false;
+    }
+    std::error_code ec;
+    {
+        std::ofstream stream(staging, std::ios::binary | std::ios::trunc);
+        if (!stream) {
+            error = "cannot open staging file for writing";
+            return false;
+        }
+        if (!contents.empty()) {
+            stream.write(reinterpret_cast<const char*>(contents.data()),
+                         static_cast<std::streamsize>(contents.size()));
+        }
+        stream.flush();
+        if (!stream) {
+            error = "failed while writing staging file";
+            stream.close();
+            std::filesystem::remove(staging, ec);
+            return false;
+        }
+    }
+
+    // The immutable dependency (or new root ledger) must reach stable storage
+    // before its atomic rename is allowed to publish it. This preserves the
+    // dependency-before-root ordering across a process or machine crash.
+    if (!FlushFileToDisk(staging, error)) {
+        std::filesystem::remove(staging, ec);
+        return false;
+    }
+
+    // Recheck both the exact parent and destination leaf immediately before
+    // publication. Replacing a regular file is intended; following or
+    // preserving a newly planted reparse point is not.
+    if (!InspectPlainPath(destination.parent_path(), true, parentExists, error) ||
+        !parentExists || !InspectPlainPath(destination, false, destinationExists, error)) {
+        if (error.empty()) error = "destination path changed before publication";
+        std::filesystem::remove(staging, ec);
+        return false;
+    }
+
+    if (!AtomicReplacePath(staging, destination, error)) {
+        std::filesystem::remove(staging, ec);
+        return false;
+    }
+    return true;
+}
+
+bool AtomicWriteText(const std::filesystem::path& destination,
+                     const std::string& contents,
+                     std::string& error) {
+    return AtomicWriteBytes(destination,
+        std::vector<std::uint8_t>(contents.begin(), contents.end()), error);
+}
+
+} // namespace advmat::rtx_bridge::detail

--- a/source/advmat_rtx_bridge/src/internal.h
+++ b/source/advmat_rtx_bridge/src/internal.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "advmat_rtx_bridge/bridge.h"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace advmat::rtx_bridge::detail {
+
+struct ImportedTexture {
+    TextureRole role;
+    std::filesystem::path absolutePath;
+    std::string layerAssetPath;
+    bool changed = false;
+};
+
+struct TextureImportConfig {
+    std::filesystem::path gameRoot;
+    std::filesystem::path modDirectory;
+    std::vector<std::filesystem::path> allowedRoots;
+    std::uintmax_t maxBytes;
+    std::uint32_t maxDimension;
+};
+
+Result ImportTexture(const TextureImportConfig& config,
+                     const std::string& profileId,
+                     const TextureInput& input,
+                     ImportedTexture& output);
+
+bool SupportsWicConversion() noexcept;
+bool SupportsTextureOperations() noexcept;
+
+bool IsDescendantOrSame(const std::filesystem::path& candidate,
+                        const std::filesystem::path& root);
+bool InspectPlainPath(const std::filesystem::path& path, bool requireDirectory,
+                      bool& exists, std::string& error);
+bool ValidatePlainDirectoryTree(const std::filesystem::path& root,
+                                const std::filesystem::path& directory,
+                                std::string& error);
+bool EnsurePlainDirectoryTree(const std::filesystem::path& root,
+                              const std::filesystem::path& directory,
+                              std::string& error);
+bool RemovePlainDirectoryTree(const std::filesystem::path& directory,
+                              std::string& error);
+bool PrunePlainDirectoryTree(const std::filesystem::path& directory,
+                             const std::vector<std::filesystem::path>& keepFiles,
+                             std::string& error);
+bool AtomicWriteText(const std::filesystem::path& destination,
+                     const std::string& contents,
+                     std::string& error);
+bool AtomicWriteBytes(const std::filesystem::path& destination,
+                      const std::vector<std::uint8_t>& contents,
+                      std::string& error);
+bool AtomicReplacePath(const std::filesystem::path& source,
+                       const std::filesystem::path& destination,
+                       std::string& error);
+std::filesystem::path MakeTemporarySibling(const std::filesystem::path& destination);
+
+std::string BuildProfileLayer(const std::vector<std::string>& hashes,
+                              const MaterialParameters& material,
+                              const std::vector<ImportedTexture>& textures);
+std::string BuildEmptyProfileLayer();
+std::string BuildModLayer(const std::vector<std::string>& profileIds);
+
+bool ValidateMaterial(const MaterialParameters& material, std::string& error);
+
+} // namespace advmat::rtx_bridge::detail
+

--- a/source/advmat_rtx_bridge/src/lua_bindings.cpp
+++ b/source/advmat_rtx_bridge/src/lua_bindings.cpp
@@ -1,0 +1,1063 @@
+#include "advmat_rtx_bridge/lua_bindings.h"
+#include "advmat_rtx_bridge/bridge.h"
+
+#include <GarrysMod/Lua/Interface.h>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <exception>
+#include <filesystem>
+#include <iomanip>
+#include <memory>
+#include <mutex>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using GarrysMod::Lua::ILuaBase;
+namespace Type = GarrysMod::Lua::Type;
+
+namespace advmat::rtx_bridge {
+namespace {
+
+std::mutex g_bridgeMutex;
+std::unique_ptr<Bridge> g_bridge;
+
+bool PushTableField(ILuaBase* lua, int table, const char* name, int& absoluteIndex) {
+    lua->GetField(table, name);
+    if (!lua->IsType(-1, Type::Table)) {
+        lua->Pop();
+        return false;
+    }
+    absoluteIndex = lua->Top();
+    return true;
+}
+
+bool ParseUtf8Path(const std::string& value, std::filesystem::path& output,
+                   std::string& error) {
+    if (value.empty() || value.size() > 2048) {
+        error = "texture source path must contain 1 to 2048 UTF-8 bytes";
+        return false;
+    }
+#ifdef _WIN32
+    const int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+        static_cast<int>(value.size()), nullptr, 0);
+    if (length <= 0) {
+        error = "texture source path is not valid UTF-8";
+        return false;
+    }
+    std::wstring wide(static_cast<std::size_t>(length), L'\0');
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+            static_cast<int>(value.size()), wide.data(), length) != length) {
+        error = "texture source path could not be converted to a Windows path";
+        return false;
+    }
+    output = std::filesystem::path(wide);
+#else
+    output = std::filesystem::path(value);
+#endif
+    return true;
+}
+
+std::string PathToUtf8(const std::filesystem::path& value) {
+#ifdef _WIN32
+    const auto& wide = value.native();
+    if (wide.empty()) return {};
+    if (wide.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        return {};
+    }
+    const auto count = static_cast<int>(wide.size());
+    const int length = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+        wide.data(), count, nullptr, 0, nullptr, nullptr);
+    if (length <= 0) return {};
+    std::string utf8(static_cast<std::size_t>(length), '\0');
+    if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS,
+            wide.data(), count, utf8.data(), length, nullptr, nullptr) != length) {
+        return {};
+    }
+    return utf8;
+#else
+    return value.u8string();
+#endif
+}
+
+bool ReadString(ILuaBase* lua, int table, const char* name,
+                std::string& output, bool& present, std::string& error) {
+    lua->GetField(table, name);
+    present = !lua->IsType(-1, Type::Nil);
+    if (!present) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::String)) {
+        error = std::string(name) + " must be a string";
+        lua->Pop();
+        return false;
+    }
+    output = lua->GetString(-1);
+    lua->Pop();
+    return true;
+}
+
+bool ReadNumber(ILuaBase* lua, int table, const char* name,
+                std::optional<float>& output, std::string& error) {
+    lua->GetField(table, name);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::Number)) {
+        error = std::string(name) + " must be a number";
+        lua->Pop();
+        return false;
+    }
+    output = static_cast<float>(lua->GetNumber(-1));
+    lua->Pop();
+    return true;
+}
+
+bool ReadInteger(ILuaBase* lua, int table, const char* name,
+                 std::optional<int>& output, std::string& error) {
+    lua->GetField(table, name);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::Number)) {
+        error = std::string(name) + " must be a number";
+        lua->Pop();
+        return false;
+    }
+    const double value = lua->GetNumber(-1);
+    lua->Pop();
+    if (!std::isfinite(value) || std::floor(value) != value ||
+        value < static_cast<double>(std::numeric_limits<int>::min()) ||
+        value > static_cast<double>(std::numeric_limits<int>::max())) {
+        error = std::string(name) + " must be an integer";
+        return false;
+    }
+    output = static_cast<int>(value);
+    return true;
+}
+
+struct EnumEntry { const char* name; int value; };
+
+bool ReadEnum(ILuaBase* lua, int table, const char* name,
+              const EnumEntry* entries, std::size_t entryCount,
+              std::optional<int>& output, std::string& error,
+              bool emptyFirstEntry = false) {
+    lua->GetField(table, name);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (lua->IsType(-1, Type::Number)) {
+        const auto value = lua->GetNumber(-1);
+        lua->Pop();
+        if (!std::isfinite(value) || std::floor(value) != value ||
+            value < std::numeric_limits<int>::min() ||
+            value > std::numeric_limits<int>::max()) {
+            error = std::string(name) + " numeric value must be an integer";
+            return false;
+        }
+        output = static_cast<int>(value);
+        return true;
+    }
+    if (!lua->IsType(-1, Type::String)) {
+        error = std::string(name) + " must be a supported name or integer";
+        lua->Pop();
+        return false;
+    }
+    std::string value = lua->GetString(-1);
+    lua->Pop();
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    for (std::size_t index = 0; index < entryCount; ++index) {
+        if (value == entries[index].name) {
+            if (emptyFirstEntry && index == 0) output.reset();
+            else output = entries[index].value;
+            return true;
+        }
+    }
+    error = std::string(name) + " contains unsupported value " + value;
+    return false;
+}
+
+bool ReadAlphaReference(ILuaBase* lua, int table, const char* name,
+                        std::optional<float>& output, std::string& error) {
+    std::optional<float> value;
+    if (!ReadNumber(lua, table, name, value, error) || !value) return error.empty();
+    if (!std::isfinite(*value) || *value < 0.0f || *value > 255.0f) {
+        error = std::string(name) + " must be in [0, 1] or an integer byte in [0, 255]";
+        return false;
+    }
+    if (*value <= 1.0f) {
+        output = *value;
+    } else if (std::floor(*value) == *value) {
+        // RemixMaterial.CreateOpaqueMaterial exposes this compatibility field
+        // as a byte. Normalize that secondary request shape to the float the
+        // installed AperturePBR MDL actually declares.
+        output = *value / 255.0f;
+    } else {
+        error = std::string(name) + " values above 1 must be integer bytes";
+        return false;
+    }
+    return true;
+}
+
+bool ReadBoolean(ILuaBase* lua, int table, const char* name,
+                 std::optional<bool>& output, std::string& error) {
+    lua->GetField(table, name);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::Bool)) {
+        error = std::string(name) + " must be a boolean";
+        lua->Pop();
+        return false;
+    }
+    output = lua->GetBool(-1);
+    lua->Pop();
+    return true;
+}
+
+bool ReadVector(ILuaBase* lua, int table, const char* name,
+                std::optional<Vec3>& output, std::string& error) {
+    int vectorTable = 0;
+    lua->GetField(table, name);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::Table)) {
+        error = std::string(name) + " must be a vector/color table";
+        lua->Pop();
+        return false;
+    }
+    vectorTable = lua->Top();
+    Vec3 value;
+    const char* xyz[3]{"x", "y", "z"};
+    const char* rgb[3]{"r", "g", "b"};
+    float* components[3]{&value.x, &value.y, &value.z};
+    for (int component = 0; component < 3; ++component) {
+        lua->GetField(vectorTable, xyz[component]);
+        if (lua->IsType(-1, Type::Nil)) {
+            lua->Pop();
+            lua->GetField(vectorTable, rgb[component]);
+        }
+        if (!lua->IsType(-1, Type::Number)) {
+            error = std::string(name) + " requires numeric x/y/z or r/g/b components";
+            lua->Pop(2);
+            return false;
+        }
+        *components[component] = static_cast<float>(lua->GetNumber(-1));
+        lua->Pop();
+    }
+    lua->Pop();
+    output = value;
+    return true;
+}
+
+std::uint64_t StableHash(std::string value) {
+    std::replace(value.begin(), value.end(), '\\', '/');
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    std::uint64_t hash = 14695981039346656037ull;
+    for (const unsigned char character : value) {
+        hash ^= character;
+        hash *= 1099511628211ull;
+    }
+    return hash;
+}
+
+std::string DerivedProfileId(ILuaBase* lua, int request, std::string& error) {
+    std::string identity;
+    bool present = false;
+    int target = 0;
+    if (PushTableField(lua, request, "target", target)) {
+        if (!ReadString(lua, target, "material", identity, present, error)) {
+            lua->Pop();
+            return {};
+        }
+        lua->Pop();
+    }
+    if (!error.empty()) return {};
+
+    if (identity.empty()) {
+        int compiled = 0;
+        if (PushTableField(lua, request, "compiled", compiled)) {
+            if (!ReadString(lua, compiled, "profile_id", identity, present, error)) {
+                lua->Pop();
+                return {};
+            }
+            lua->Pop();
+        }
+    }
+    if (identity.empty()) {
+        int profile = 0;
+        if (PushTableField(lua, request, "profile", profile)) {
+            if (!ReadString(lua, profile, "profile_id", identity, present, error)) {
+                lua->Pop();
+                return {};
+            }
+            lua->Pop();
+        }
+    }
+    if (identity.empty()) {
+        error = "request.target.material is required to identify an owned replacement";
+        return {};
+    }
+    std::ostringstream id;
+    id << "material_" << std::uppercase << std::hex << std::setfill('0')
+       << std::setw(16) << StableHash(identity);
+    return id.str();
+}
+
+bool ParseHashes(ILuaBase* lua, int request, std::vector<std::string>& hashes,
+                 std::string& error) {
+    int table = 0;
+    if (!PushTableField(lua, request, "hashes", table)) {
+        error = "request.hashes must be an array of hexadecimal strings";
+        return false;
+    }
+    const auto count = lua->ObjLen(table);
+    if (count == 0 || count > 128) {
+        error = "request.hashes must contain one to 128 entries";
+        lua->Pop();
+        return false;
+    }
+    hashes.reserve(count);
+    for (int index = 1; index <= count; ++index) {
+        lua->PushNumber(static_cast<double>(index));
+        lua->GetTable(table);
+        if (!lua->IsType(-1, Type::String)) {
+            error = "every request.hashes entry must be a hexadecimal string";
+            lua->Pop(2);
+            return false;
+        }
+        hashes.emplace_back(lua->GetString(-1));
+        lua->Pop();
+    }
+    lua->Pop();
+    return true;
+}
+
+std::optional<TextureRole> ParseRole(const std::string& value) {
+    if (value == "albedo" || value == "base_color" || value == "basecolor") return TextureRole::Albedo;
+    if (value == "normal") return TextureRole::Normal;
+    if (value == "anisotropy") return TextureRole::Anisotropy;
+    if (value == "roughness") return TextureRole::Roughness;
+    if (value == "metallic" || value == "metalness") return TextureRole::Metallic;
+    if (value == "height" || value == "displacement") return TextureRole::Height;
+    if (value == "emissive" || value == "emission") return TextureRole::Emissive;
+    if (value == "subsurface_transmittance") return TextureRole::SubsurfaceTransmittance;
+    if (value == "subsurface_thickness") return TextureRole::SubsurfaceThickness;
+    if (value == "subsurface_scattering") return TextureRole::SubsurfaceScattering;
+    if (value == "subsurface_radius") return TextureRole::SubsurfaceRadius;
+    return std::nullopt;
+}
+
+bool ParseOperation(ILuaBase* lua, int table, TextureOperation& operation,
+                    std::string& error) {
+    std::string kind;
+    bool present = false;
+    if (!ReadString(lua, table, "op", kind, present, error) || !present) {
+        if (error.empty()) error = "texture operation requires an op string";
+        return false;
+    }
+    std::transform(kind.begin(), kind.end(), kind.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    if (kind == "invert") {
+        operation.kind = TextureOperationKind::Invert;
+    } else if (kind == "multiply") {
+        operation.kind = TextureOperationKind::Multiply;
+    } else if (kind == "normal_from_height") {
+        operation.kind = TextureOperationKind::NormalFromHeight;
+    } else {
+        error = "unsupported texture operation: " + kind;
+        return false;
+    }
+
+    std::optional<float> strength;
+    if (!ReadNumber(lua, table, "strength", strength, error)) return false;
+    if (strength) operation.strength = *strength;
+
+    std::string channel;
+    if (!ReadString(lua, table, "channel", channel, present, error)) return false;
+    if (present) {
+        std::transform(channel.begin(), channel.end(), channel.begin(), [](unsigned char character) {
+            return static_cast<char>(std::tolower(character));
+        });
+        if (channel == "luminance") operation.channel = HeightChannel::Luminance;
+        else if (channel == "r") operation.channel = HeightChannel::Red;
+        else if (channel == "g") operation.channel = HeightChannel::Green;
+        else if (channel == "b") operation.channel = HeightChannel::Blue;
+        else if (channel == "a") operation.channel = HeightChannel::Alpha;
+        else {
+            error = "normal_from_height channel must be luminance, r, g, b or a";
+            return false;
+        }
+    }
+
+    std::optional<Vec3> color;
+    if (!ReadVector(lua, table, "color", color, error)) return false;
+    if (color) {
+        operation.color = *color;
+    } else {
+        std::optional<float> factor;
+        if (!ReadNumber(lua, table, "factor", factor, error)) return false;
+        if (!factor && !ReadNumber(lua, table, "value", factor, error)) return false;
+        if (factor) operation.color = {*factor, *factor, *factor};
+    }
+    return true;
+}
+
+bool ParseMapValue(ILuaBase* lua, int valueIndex, TextureRole role,
+                   TextureInput& texture, std::string& error) {
+    texture.role = role;
+    if (lua->IsType(valueIndex, Type::String)) {
+        return ParseUtf8Path(lua->GetString(valueIndex), texture.source, error);
+    }
+    if (!lua->IsType(valueIndex, Type::Table)) {
+        error = std::string(TextureRoleName(role)) + " map must be a path or descriptor table";
+        return false;
+    }
+    std::string source;
+    bool present = false;
+    if (!ReadString(lua, valueIndex, "generatedFile", source, present, error)) return false;
+    if (!present) {
+        if (!ReadString(lua, valueIndex, "source", source, present, error) || !present) {
+            if (error.empty()) error = std::string(TextureRoleName(role)) + " map descriptor requires source";
+            return false;
+        }
+    }
+    if (!ParseUtf8Path(source, texture.source, error)) return false;
+
+    int operations = 0;
+    if (PushTableField(lua, valueIndex, "ops", operations)) {
+        const auto count = lua->ObjLen(operations);
+        if (count > static_cast<int>(kMaxTextureOperations)) {
+            error = "texture map cannot contain more than " +
+                std::to_string(kMaxTextureOperations) + " operations";
+            lua->Pop();
+            return false;
+        }
+        for (int index = 1; index <= count; ++index) {
+            lua->PushNumber(static_cast<double>(index));
+            lua->GetTable(operations);
+            if (!lua->IsType(-1, Type::Table)) {
+                error = "texture operations must be tables";
+                lua->Pop(2);
+                return false;
+            }
+            const int operationTable = lua->Top();
+            TextureOperation operation;
+            if (!ParseOperation(lua, operationTable, operation, error)) {
+                lua->Pop(2);
+                return false;
+            }
+            texture.operations.push_back(operation);
+            lua->Pop();
+        }
+        lua->Pop();
+    }
+    return true;
+}
+
+bool ParseMaps(ILuaBase* lua, int table, MaterialParameters& material,
+               std::string& error) {
+    static const char* roles[]{"albedo", "normal", "anisotropy", "roughness",
+                               "metallic", "height", "emissive",
+                               "subsurface_transmittance", "subsurface_thickness",
+                               "subsurface_scattering", "subsurface_radius"};
+    static_assert(sizeof(roles) / sizeof(roles[0]) == kTextureRoleCount);
+    for (const char* roleName : roles) {
+        lua->GetField(table, roleName);
+        if (lua->IsType(-1, Type::Nil)) {
+            lua->Pop();
+            continue;
+        }
+        TextureInput texture;
+        if (!ParseMapValue(lua, lua->Top(), *ParseRole(roleName), texture, error)) {
+            lua->Pop();
+            return false;
+        }
+        material.textures.push_back(std::move(texture));
+        lua->Pop();
+    }
+    return true;
+}
+
+bool ParsePbr(ILuaBase* lua, int pbr, MaterialParameters& material,
+              std::string& error) {
+    int constants = 0;
+    if (PushTableField(lua, pbr, "constants", constants)) {
+        const bool ok =
+            ReadVector(lua, constants, "albedo", material.albedo, error) &&
+            ReadNumber(lua, constants, "opacity", material.opacity, error) &&
+            ReadNumber(lua, constants, "roughness", material.roughness, error) &&
+            ReadNumber(lua, constants, "metallic", material.metallic, error) &&
+            ReadVector(lua, constants, "emissive_color", material.emissiveColor, error) &&
+            ReadNumber(lua, constants, "emissive_intensity", material.emissiveIntensity, error) &&
+            ReadNumber(lua, constants, "anisotropy", material.anisotropy, error) &&
+            ReadNumber(lua, constants, "thin_film_thickness", material.thinFilmThickness, error) &&
+            ReadNumber(lua, constants, "displace_in", material.displaceIn, error) &&
+            ReadNumber(lua, constants, "displace_out", material.displaceOut, error) &&
+            ReadVector(lua, constants, "subsurface_transmittance_color",
+                       material.subsurfaceTransmittanceColor, error) &&
+            ReadNumber(lua, constants, "subsurface_measurement_distance",
+                       material.subsurfaceMeasurementDistance, error) &&
+            ReadVector(lua, constants, "subsurface_single_scattering_albedo",
+                       material.subsurfaceSingleScatteringAlbedo, error) &&
+            ReadNumber(lua, constants, "subsurface_volumetric_anisotropy",
+                       material.subsurfaceVolumetricAnisotropy, error) &&
+            ReadVector(lua, constants, "subsurface_radius",
+                       material.subsurfaceRadius, error) &&
+            ReadNumber(lua, constants, "subsurface_radius_scale",
+                       material.subsurfaceRadiusScale, error) &&
+            ReadNumber(lua, constants, "subsurface_max_sample_radius",
+                       material.subsurfaceMaxSampleRadius, error);
+        lua->Pop();
+        if (!ok) return false;
+        // Zero is the schema's explicit "thin film disabled" sentinel. The
+        // Remix API only has an optional positive thickness value.
+        if (material.thinFilmThickness && *material.thinFilmThickness == 0.0f) {
+            material.thinFilmThickness.reset();
+        }
+    }
+    int maps = 0;
+    if (PushTableField(lua, pbr, "maps", maps)) {
+        const bool ok = ParseMaps(lua, maps, material, error);
+        lua->Pop();
+        if (!ok) return false;
+    }
+    int options = 0;
+    if (PushTableField(lua, pbr, "options", options)) {
+        static const EnumEntry filterModes[]{
+            {"nearest", 0}, {"linear", 1},
+        };
+        static const EnumEntry wrapModes[]{
+            {"clamp", 0}, {"repeat", 1}, {"mirror", 2}, {"clip", 3},
+        };
+        static const EnumEntry normalEncodings[]{
+            {"octahedral", 0}, {"tangent_space_ogl", 1}, {"tangent_space_dx", 2},
+        };
+        // Opaque is represented by no authored blend type; any explicit type
+        // enables blending in the generated layer.
+        static const EnumEntry blendTypes[]{
+            {"opaque", 0},
+            {"alpha", 0},
+            {"alpha_emissive", 1},
+            {"reverse_alpha_emissive", 2},
+            {"color", 3},
+            {"color_emissive", 4},
+            {"reverse_color_emissive", 5},
+            {"emissive", 6},
+            {"multiplicative", 7},
+            {"double_multiplicative", 8},
+        };
+        static const EnumEntry alphaTests[]{
+            {"none", 0}, {"always", 0}, {"never", 1}, {"less", 2},
+            {"equal", 3}, {"less_equal", 4}, {"greater", 5},
+            {"not_equal", 6}, {"greater_equal", 7},
+        };
+        const bool ok =
+            ReadInteger(lua, options, "sprite_sheet_rows", material.spriteSheetRows, error) &&
+            ReadInteger(lua, options, "sprite_sheet_columns", material.spriteSheetColumns, error) &&
+            ReadInteger(lua, options, "sprite_sheet_fps", material.spriteSheetFps, error) &&
+            ReadEnum(lua, options, "filter_mode", filterModes, 2, material.filterMode, error) &&
+            ReadEnum(lua, options, "wrap_u", wrapModes, 4, material.wrapModeU, error) &&
+            ReadEnum(lua, options, "wrap_v", wrapModes, 4, material.wrapModeV, error) &&
+            ReadEnum(lua, options, "normal_encoding", normalEncodings, 3,
+                     material.normalEncoding, error) &&
+            ReadBoolean(lua, options, "enable_thin_film", material.enableThinFilm, error) &&
+            ReadBoolean(lua, options, "enable_emission", material.enableEmission, error) &&
+            ReadBoolean(lua, options, "preload_textures", material.preloadTextures, error) &&
+            ReadBoolean(lua, options, "ignore_material", material.ignoreMaterial, error) &&
+            ReadBoolean(lua, options, "alpha_is_thin_film", material.alphaIsThinFilmThickness, error) &&
+            ReadBoolean(lua, options, "use_draw_call_alpha", material.useDrawCallAlphaState, error) &&
+            ReadBoolean(lua, options, "blend_enabled", material.blendEnabled, error) &&
+            ReadBoolean(lua, options, "inverted_blend", material.invertedBlend, error) &&
+            ReadBoolean(lua, options, "subsurface_diffusion_profile",
+                        material.subsurfaceDiffusionProfile, error) &&
+            ReadEnum(lua, options, "blend_type", blendTypes, 10,
+                     material.blendType, error, true) &&
+            ReadEnum(lua, options, "alpha_test_type", alphaTests, 9,
+                     material.alphaTestType, error) &&
+            ReadAlphaReference(lua, options, "alpha_reference", material.alphaReferenceValue, error);
+        lua->Pop();
+        if (!ok) return false;
+    }
+    return true;
+}
+
+bool AddDirectMap(ILuaBase* lua, int table, const char* field, TextureRole role,
+                  MaterialParameters& material, std::string& error) {
+    lua->GetField(table, field);
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    TextureInput texture;
+    const bool ok = ParseMapValue(lua, lua->Top(), role, texture, error);
+    lua->Pop();
+    if (ok) material.textures.push_back(std::move(texture));
+    return ok;
+}
+
+bool ParseDirectTables(ILuaBase* lua, int request, MaterialParameters& material,
+                       std::string& error) {
+    int info = 0;
+    if (PushTableField(lua, request, "materialInfo", info)) {
+        const bool ok =
+            AddDirectMap(lua, info, "albedoTexture", TextureRole::Albedo, material, error) &&
+            AddDirectMap(lua, info, "normalTexture", TextureRole::Normal, material, error) &&
+            AddDirectMap(lua, info, "emissiveTexture", TextureRole::Emissive, material, error) &&
+            ReadNumber(lua, info, "emissiveIntensity", material.emissiveIntensity, error) &&
+            ReadVector(lua, info, "emissiveColorConstant", material.emissiveColor, error) &&
+            ReadInteger(lua, info, "spriteSheetRow", material.spriteSheetRows, error) &&
+            ReadInteger(lua, info, "spriteSheetCol", material.spriteSheetColumns, error) &&
+            ReadInteger(lua, info, "spriteSheetFps", material.spriteSheetFps, error) &&
+            ReadInteger(lua, info, "filterMode", material.filterMode, error) &&
+            ReadInteger(lua, info, "wrapModeU", material.wrapModeU, error) &&
+            ReadInteger(lua, info, "wrapModeV", material.wrapModeV, error);
+        lua->Pop();
+        if (!ok) return false;
+    }
+    int opaque = 0;
+    if (PushTableField(lua, request, "opaqueInfo", opaque)) {
+        const bool ok =
+            AddDirectMap(lua, opaque, "roughnessTexture", TextureRole::Roughness, material, error) &&
+            AddDirectMap(lua, opaque, "metallicTexture", TextureRole::Metallic, material, error) &&
+            AddDirectMap(lua, opaque, "heightTexture", TextureRole::Height, material, error) &&
+            AddDirectMap(lua, opaque, "anisotropyTexture", TextureRole::Anisotropy, material, error) &&
+            ReadNumber(lua, opaque, "anisotropy", material.anisotropy, error) &&
+            ReadVector(lua, opaque, "albedoConstant", material.albedo, error) &&
+            ReadNumber(lua, opaque, "opacityConstant", material.opacity, error) &&
+            ReadNumber(lua, opaque, "roughnessConstant", material.roughness, error) &&
+            ReadNumber(lua, opaque, "metallicConstant", material.metallic, error) &&
+            ReadNumber(lua, opaque, "thinFilmThickness", material.thinFilmThickness, error) &&
+            ReadBoolean(lua, opaque, "alphaIsThinFilmThickness", material.alphaIsThinFilmThickness, error) &&
+            ReadBoolean(lua, opaque, "useDrawCallAlphaState", material.useDrawCallAlphaState, error) &&
+            ReadBoolean(lua, opaque, "invertedBlend", material.invertedBlend, error) &&
+            ReadInteger(lua, opaque, "blendType", material.blendType, error) &&
+            ReadInteger(lua, opaque, "alphaTestType", material.alphaTestType, error) &&
+            ReadAlphaReference(lua, opaque, "alphaReferenceValue", material.alphaReferenceValue, error) &&
+            ReadNumber(lua, opaque, "displaceIn", material.displaceIn, error) &&
+            ReadNumber(lua, opaque, "displaceOut", material.displaceOut, error);
+        lua->Pop();
+        if (!ok) return false;
+    }
+    return true;
+}
+
+bool ParseMaterial(ILuaBase* lua, int request, MaterialParameters& material,
+                   std::string& error) {
+    lua->GetField(request, "compiled");
+    if (!lua->IsType(-1, Type::Nil)) {
+        if (!lua->IsType(-1, Type::Table)) {
+            error = "request.compiled must be a table";
+            lua->Pop();
+            return false;
+        }
+        const int compiled = lua->Top();
+        lua->GetField(compiled, "pbr");
+        if (!lua->IsType(-1, Type::Table)) {
+            error = "request.compiled.pbr must be a table";
+            lua->Pop(2);
+            return false;
+        }
+        const int pbr = lua->Top();
+        const bool ok = ParsePbr(lua, pbr, material, error);
+        lua->Pop(2);
+        return ok;
+    }
+    lua->Pop();
+
+    lua->GetField(request, "profile");
+    if (!lua->IsType(-1, Type::Nil)) {
+        if (!lua->IsType(-1, Type::Table)) {
+            error = "request.profile must be a table";
+            lua->Pop();
+            return false;
+        }
+        const int profile = lua->Top();
+        lua->GetField(profile, "pbr");
+        if (!lua->IsType(-1, Type::Table)) {
+            error = "request.profile.pbr must be a table when compiled is absent";
+            lua->Pop(2);
+            return false;
+        }
+        const int pbr = lua->Top();
+        const bool ok = ParsePbr(lua, pbr, material, error);
+        lua->Pop();
+        lua->Pop();
+        return ok;
+    }
+    lua->Pop();
+    return ParseDirectTables(lua, request, material, error);
+}
+
+bool ValidateProtocol(ILuaBase* lua, int request, std::string& error) {
+    lua->GetField(request, "protocol");
+    if (lua->IsType(-1, Type::Nil)) {
+        lua->Pop();
+        return true;
+    }
+    if (!lua->IsType(-1, Type::Number) || lua->GetNumber(-1) != kApiVersion) {
+        lua->Pop();
+        error = "unsupported bridge protocol; expected 1";
+        return false;
+    }
+    lua->Pop();
+    return true;
+}
+
+void PushFailure(ILuaBase* lua, const std::string& reason) {
+    lua->PushBool(false);
+    lua->PushString(reason.c_str());
+}
+
+void PushResultTable(ILuaBase* lua, const Result& result) {
+    lua->CreateTable();
+    lua->PushString(result.code.c_str());
+    lua->SetField(-2, "code");
+    lua->PushString(result.profileId.c_str());
+    lua->SetField(-2, "profileId");
+    const auto layer = PathToUtf8(result.layerPath);
+    lua->PushString(layer.c_str());
+    lua->SetField(-2, "layerPath");
+    lua->CreateTable();
+    int layerIndex = 1;
+    for (const auto& layerPath : result.layerPaths) {
+        const auto path = PathToUtf8(layerPath);
+        lua->PushNumber(layerIndex++);
+        lua->PushString(path.c_str());
+        lua->SetTable(-3);
+    }
+    lua->SetField(-2, "layerPaths");
+    lua->CreateTable();
+    int index = 1;
+    for (const auto& texture : result.importedTextures) {
+        const auto path = PathToUtf8(texture);
+        lua->PushNumber(index++);
+        lua->PushString(path.c_str());
+        lua->SetTable(-3);
+    }
+    lua->SetField(-2, "importedTextures");
+}
+
+int Apply(ILuaBase* lua) {
+    if (!lua->IsType(1, Type::Table)) {
+        PushFailure(lua, "request must be a table");
+        return 2;
+    }
+    std::string error;
+    if (!ValidateProtocol(lua, 1, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    std::string operationName;
+    bool operationPresent = false;
+    if (!ReadString(lua, 1, "operation", operationName, operationPresent, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    BridgeOperation operation = BridgeOperation::Commit;
+    if (!ParseBridgeOperation(operationPresent ? operationName : std::string{}, operation, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    if (operation == BridgeOperation::Preview) {
+        PushFailure(lua,
+            "preview_unsupported: protocol 1 cannot provide reversible live preview without publishing persistent USDA state");
+        return 2;
+    }
+    const auto profileId = DerivedProfileId(lua, 1, error);
+    if (!error.empty()) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    std::vector<std::string> clearHashes;
+    if ((operation == BridgeOperation::Restore || operation == BridgeOperation::Clear) &&
+        !ParseHashes(lua, 1, clearHashes, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+
+    if (operation == BridgeOperation::Restore || operation == BridgeOperation::Clear) {
+        Result result;
+        bool initialized = false;
+        {
+            std::lock_guard<std::mutex> lock(g_bridgeMutex);
+            initialized = static_cast<bool>(g_bridge);
+            if (initialized) {
+                result = g_bridge->ClearLegacyMaterial(
+                    {profileId, std::move(clearHashes)});
+            }
+        }
+        if (!initialized) {
+            PushFailure(lua, "native bridge is not initialized");
+            return 2;
+        }
+        if (!result.ok) {
+            PushFailure(lua, result.code + ": " + result.message);
+            return 2;
+        }
+        lua->PushBool(true);
+        PushResultTable(lua, result);
+        return 2;
+    }
+
+    ApplyRequest request;
+    request.operation = operation;
+    request.profileId = profileId;
+    if (!ParseHashes(lua, 1, request.hashes, error) ||
+        !ParseMaterial(lua, 1, request.material, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    if (request.material.thinFilmThickness &&
+        *request.material.thinFilmThickness == 0.0f) {
+        request.material.thinFilmThickness.reset();
+    }
+    Result result;
+    bool initialized = false;
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        initialized = static_cast<bool>(g_bridge);
+        if (initialized) {
+            result = g_bridge->ApplyLegacyMaterial(request);
+        }
+    }
+    if (!initialized) {
+        PushFailure(lua, "native bridge is not initialized");
+        return 2;
+    }
+    if (!result.ok) {
+        PushFailure(lua, result.code + ": " + result.message);
+        return 2;
+    }
+    lua->PushBool(true);
+    PushResultTable(lua, result);
+    return 2;
+}
+
+int Clear(ILuaBase* lua) {
+    if (!lua->IsType(1, Type::Table)) {
+        PushFailure(lua, "request must be a table");
+        return 2;
+    }
+    std::string error;
+    if (!ValidateProtocol(lua, 1, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    std::vector<std::string> hashes;
+    if (!ParseHashes(lua, 1, hashes, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    const auto profileId = DerivedProfileId(lua, 1, error);
+    if (!error.empty()) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    Result result;
+    bool initialized = false;
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        initialized = static_cast<bool>(g_bridge);
+        if (initialized) {
+            result = g_bridge->ClearLegacyMaterial(
+                {profileId, std::move(hashes)});
+        }
+    }
+    if (!initialized) {
+        PushFailure(lua, "native bridge is not initialized");
+        return 2;
+    }
+    if (!result.ok) {
+        PushFailure(lua, result.code + ": " + result.message);
+        return 2;
+    }
+    lua->PushBool(true);
+    PushResultTable(lua, result);
+    return 2;
+}
+
+int ClearAll(ILuaBase* lua) {
+    if (!lua->IsType(1, Type::Table)) {
+        PushFailure(lua, "request must be a table");
+        return 2;
+    }
+    std::string error;
+    if (!ValidateProtocol(lua, 1, error)) {
+        PushFailure(lua, error);
+        return 2;
+    }
+    Result result;
+    bool initialized = false;
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        initialized = static_cast<bool>(g_bridge);
+        if (initialized) {
+            result = g_bridge->ClearAllOwned();
+        }
+    }
+    if (!initialized) {
+        PushFailure(lua, "native bridge is not initialized");
+        return 2;
+    }
+    if (!result.ok) {
+        PushFailure(lua, result.code + ": " + result.message);
+        return 2;
+    }
+    lua->PushBool(true);
+    PushResultTable(lua, result);
+    return 2;
+}
+
+int GetCapabilities(ILuaBase* lua) {
+    std::optional<Capabilities> capabilities;
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        if (g_bridge) {
+            capabilities = g_bridge->GetCapabilities();
+        }
+    }
+    if (!capabilities) {
+        lua->CreateTable();
+        lua->PushNumber(kApiVersion); lua->SetField(-2, "apiVersion");
+        lua->PushBool(false); lua->SetField(-2, "legacyMaterialOverrides");
+        lua->PushBool(false); lua->SetField(-2, "livePreview");
+        lua->PushBool(false); lua->SetField(-2, "authoritativeReset");
+        lua->PushBool(true); lua->SetField(-2, "synchronous");
+        return 1;
+    }
+    lua->CreateTable();
+    lua->PushNumber(capabilities->apiVersion); lua->SetField(-2, "apiVersion");
+    lua->PushBool(capabilities->available); lua->SetField(-2, "legacyMaterialOverrides");
+    lua->PushBool(capabilities->livePreview); lua->SetField(-2, "livePreview");
+    lua->PushBool(capabilities->available && capabilities->authoritativeReset);
+    lua->SetField(-2, "authoritativeReset");
+    lua->PushBool(capabilities->available); lua->SetField(-2, "textureWriter");
+    lua->PushBool(capabilities->atomicProfileLayers); lua->SetField(-2, "atomicProfileLayers");
+    lua->PushBool(capabilities->ddsImport); lua->SetField(-2, "ddsImport");
+    lua->PushBool(capabilities->wicImageConversion); lua->SetField(-2, "wicImageConversion");
+    lua->PushBool(capabilities->textureOperations); lua->SetField(-2, "textureOperations");
+    lua->PushBool(capabilities->synchronous); lua->SetField(-2, "synchronous");
+    lua->PushNumber(static_cast<double>(capabilities->maxTextureBytes));
+    lua->SetField(-2, "maxTextureBytes");
+    lua->PushNumber(static_cast<double>(capabilities->maxTextureDimension));
+    lua->SetField(-2, "maxTextureDimension");
+    lua->PushNumber(static_cast<double>(capabilities->maxTextureOperations));
+    lua->SetField(-2, "maxTextureOperations");
+    lua->PushNumber(static_cast<double>(capabilities->maxActiveProfiles));
+    lua->SetField(-2, "maxActiveProfiles");
+    lua->PushNumber(static_cast<double>(capabilities->maxActiveTextureFiles));
+    lua->SetField(-2, "maxActiveTextureFiles");
+    lua->PushNumber(static_cast<double>(capabilities->maxActiveTextureBytes));
+    lua->SetField(-2, "maxActiveTextureBytes");
+    const auto modDirectory = PathToUtf8(capabilities->modDirectory);
+    lua->PushString(modDirectory.c_str()); lua->SetField(-2, "modDirectory");
+    return 1;
+}
+
+using LuaCall = int (*)(ILuaBase*);
+
+int GuardLuaCall(ILuaBase* lua, LuaCall call) noexcept {
+    try {
+        return call(lua);
+    } catch (const std::exception& exception) {
+        try {
+            lua->PushBool(false);
+            lua->PushString(exception.what());
+            return 2;
+        } catch (...) {
+            return 0;
+        }
+    } catch (...) {
+        try {
+            lua->PushBool(false);
+            lua->PushString("native bridge operation failed");
+            return 2;
+        } catch (...) {
+            return 0;
+        }
+    }
+}
+
+LUA_FUNCTION(AdvMatRTXBridge_Capabilities) {
+    return GuardLuaCall(LUA, GetCapabilities);
+}
+LUA_FUNCTION(AdvMatRTXBridge_ApplyLegacyMaterial) {
+    return GuardLuaCall(LUA, Apply);
+}
+LUA_FUNCTION(AdvMatRTXBridge_ClearLegacyMaterial) {
+    return GuardLuaCall(LUA, Clear);
+}
+LUA_FUNCTION(AdvMatRTXBridge_ClearAllOwned) {
+    return GuardLuaCall(LUA, ClearAll);
+}
+
+} // namespace
+
+bool RegisterLua(ILuaBase* lua, const std::filesystem::path& gameRoot) {
+    if (!lua) return false;
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        Config config;
+        config.gameRoot = gameRoot;
+        g_bridge = std::make_unique<Bridge>(std::move(config));
+    }
+    lua->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+    lua->CreateTable();
+    lua->PushNumber(kApiVersion);
+    lua->SetField(-2, "API_VERSION");
+    lua->PushCFunction(AdvMatRTXBridge_Capabilities);
+    lua->SetField(-2, "Capabilities");
+    lua->PushCFunction(AdvMatRTXBridge_ApplyLegacyMaterial);
+    lua->SetField(-2, "ApplyLegacyMaterial");
+    lua->PushCFunction(AdvMatRTXBridge_ClearLegacyMaterial);
+    lua->SetField(-2, "ClearLegacyMaterial");
+    lua->PushCFunction(AdvMatRTXBridge_ClearAllOwned);
+    lua->SetField(-2, "ClearAllOwned");
+    lua->SetField(-2, "AdvMatRTXBridge");
+    lua->Pop();
+    return true;
+}
+
+void UnregisterLua(ILuaBase* lua) {
+    {
+        std::lock_guard<std::mutex> lock(g_bridgeMutex);
+        g_bridge.reset();
+    }
+    if (!lua) return;
+    try {
+        lua->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
+        lua->PushNil();
+        lua->SetField(-2, "AdvMatRTXBridge");
+        lua->Pop();
+    } catch (...) {
+        // Module teardown must continue even if the Lua state is already
+        // partially unavailable. The native writer has already been released.
+    }
+}
+
+} // namespace advmat::rtx_bridge

--- a/source/advmat_rtx_bridge/src/texture_ingest.cpp
+++ b/source/advmat_rtx_bridge/src/texture_ingest.cpp
@@ -1,0 +1,815 @@
+#include "internal.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <system_error>
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <Windows.h>
+#include <wincodec.h>
+#endif
+
+namespace advmat::rtx_bridge::detail {
+namespace {
+
+constexpr std::array<std::uint8_t, 4> kDdsMagic{'D', 'D', 'S', ' '};
+
+constexpr std::uint32_t FourCc(char a, char b, char c, char d) {
+    return static_cast<std::uint32_t>(static_cast<unsigned char>(a)) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(b)) << 8u) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(c)) << 16u) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(d)) << 24u);
+}
+
+enum class DdsStorage { BitsPerPixel, BlockCompressed, PackedPairs };
+
+struct DdsLayout {
+    DdsStorage storage;
+    std::uint32_t unit;
+};
+
+std::string Lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    return value;
+}
+
+bool ReadFile(const std::filesystem::path& path, std::uintmax_t maximum,
+              std::vector<std::uint8_t>& bytes, std::string& error) {
+    std::error_code ec;
+    const auto size = std::filesystem::file_size(path, ec);
+    if (ec) {
+        error = "cannot determine texture size: " + ec.message();
+        return false;
+    }
+    if (size == 0 || size > maximum || size > static_cast<std::uintmax_t>(
+            std::numeric_limits<std::streamsize>::max())) {
+        error = "texture size is empty or exceeds the configured safety limit";
+        return false;
+    }
+    bytes.resize(static_cast<std::size_t>(size));
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream || !stream.read(reinterpret_cast<char*>(bytes.data()),
+                                static_cast<std::streamsize>(bytes.size()))) {
+        error = "cannot read texture source";
+        return false;
+    }
+    return true;
+}
+
+std::uint32_t ReadU32(const std::vector<std::uint8_t>& bytes, std::size_t offset) {
+    return static_cast<std::uint32_t>(bytes[offset]) |
+        (static_cast<std::uint32_t>(bytes[offset + 1]) << 8u) |
+        (static_cast<std::uint32_t>(bytes[offset + 2]) << 16u) |
+        (static_cast<std::uint32_t>(bytes[offset + 3]) << 24u);
+}
+
+std::optional<DdsLayout> LegacyFourCcLayout(std::uint32_t fourCc) {
+    switch (fourCc) {
+    case FourCc('D', 'X', 'T', '1'):
+    case FourCc('A', 'T', 'I', '1'):
+    case FourCc('B', 'C', '4', 'U'):
+    case FourCc('B', 'C', '4', 'S'):
+        return DdsLayout{DdsStorage::BlockCompressed, 8};
+    case FourCc('D', 'X', 'T', '2'):
+    case FourCc('D', 'X', 'T', '3'):
+    case FourCc('D', 'X', 'T', '4'):
+    case FourCc('D', 'X', 'T', '5'):
+    case FourCc('A', 'T', 'I', '2'):
+    case FourCc('B', 'C', '5', 'U'):
+    case FourCc('B', 'C', '5', 'S'):
+    case FourCc('A', '2', 'D', '5'):
+    case FourCc('x', 'G', 'B', 'R'):
+    case FourCc('R', 'x', 'B', 'G'):
+    case FourCc('R', 'B', 'x', 'G'):
+    case FourCc('x', 'R', 'B', 'G'):
+    case FourCc('R', 'G', 'x', 'B'):
+    case FourCc('x', 'G', 'x', 'R'):
+    case FourCc('G', 'X', 'R', 'B'):
+    case FourCc('G', 'R', 'X', 'B'):
+    case FourCc('R', 'X', 'G', 'B'):
+    case FourCc('B', 'R', 'G', 'X'):
+    case FourCc('A', '2', 'X', 'Y'):
+    case FourCc('B', 'C', '6', 'H'):
+    case FourCc('B', 'C', '7', 'L'):
+    case FourCc('B', 'C', '7', '\0'):
+        return DdsLayout{DdsStorage::BlockCompressed, 16};
+    case FourCc('R', 'G', 'B', 'G'):
+    case FourCc('G', 'R', 'G', 'B'):
+    case FourCc('U', 'Y', 'V', 'Y'):
+    case FourCc('Y', 'U', 'Y', '2'):
+        return DdsLayout{DdsStorage::PackedPairs, 4};
+    // DDS writers historically place only this documented subset of
+    // D3DFORMAT enum values in dwFourCC. Reject the lower enum values because
+    // they collide with ad-hoc DXGI-in-FourCC files and have ambiguous sizes.
+    case 36: case 110: case 113: case 115:
+        return DdsLayout{DdsStorage::BitsPerPixel, 64};
+    case 111:
+        return DdsLayout{DdsStorage::BitsPerPixel, 16};
+    case 112: case 114:
+        return DdsLayout{DdsStorage::BitsPerPixel, 32};
+    case 116:
+        return DdsLayout{DdsStorage::BitsPerPixel, 128};
+    default:
+        return std::nullopt;
+    }
+}
+
+std::optional<DdsLayout> DxgiLayout(std::uint32_t format) {
+    switch (format) {
+    case 70: case 71: case 72:
+    case 79: case 80: case 81:
+        return DdsLayout{DdsStorage::BlockCompressed, 8};
+    case 73: case 74: case 75:
+    case 76: case 77: case 78:
+    case 82: case 83: case 84:
+    case 94: case 95: case 96:
+    case 97: case 98: case 99:
+        return DdsLayout{DdsStorage::BlockCompressed, 16};
+    case 68: case 69:
+        return DdsLayout{DdsStorage::PackedPairs, 4};
+    case 1: case 2: case 3: case 4:
+        return DdsLayout{DdsStorage::BitsPerPixel, 128};
+    case 5: case 6: case 7: case 8:
+        return DdsLayout{DdsStorage::BitsPerPixel, 96};
+    case 9: case 10: case 11: case 12: case 13: case 14:
+    case 15: case 16: case 17: case 18:
+    case 19: case 20: case 21: case 22:
+        return DdsLayout{DdsStorage::BitsPerPixel, 64};
+    case 23: case 24: case 25: case 26:
+    case 27: case 28: case 29: case 30: case 31: case 32:
+    case 33: case 34: case 35: case 36: case 37: case 38:
+    case 39: case 40: case 41: case 42: case 43:
+    case 44: case 45: case 46: case 47:
+    case 67: case 87: case 88: case 89: case 90: case 91: case 92: case 93:
+        return DdsLayout{DdsStorage::BitsPerPixel, 32};
+    case 48: case 49: case 50: case 51: case 52:
+    case 53: case 54: case 55: case 56: case 57: case 58: case 59:
+    case 85: case 86: case 115: case 191:
+        return DdsLayout{DdsStorage::BitsPerPixel, 16};
+    case 60: case 61: case 62: case 63: case 64: case 65:
+        return DdsLayout{DdsStorage::BitsPerPixel, 8};
+    case 66:
+        return DdsLayout{DdsStorage::BitsPerPixel, 1};
+    default:
+        return std::nullopt;
+    }
+}
+
+bool MultiplyWithin(std::uintmax_t left, std::uintmax_t right,
+                    std::uintmax_t limit, std::uintmax_t& product) {
+    if (left != 0 && right > limit / left) return false;
+    product = left * right;
+    return true;
+}
+
+bool AddDdsMipBytes(const DdsLayout& layout, std::uint32_t width,
+                     std::uint32_t height, std::uintmax_t& required,
+                     std::uintmax_t available) {
+    if (required > available) return false;
+    const auto remaining = available - required;
+    std::uintmax_t levelBytes = 0;
+    if (layout.storage == DdsStorage::BlockCompressed) {
+        const auto blocksWide = std::max<std::uintmax_t>(
+            1, (static_cast<std::uintmax_t>(width) + 3u) / 4u);
+        const auto blocksHigh = std::max<std::uintmax_t>(
+            1, (static_cast<std::uintmax_t>(height) + 3u) / 4u);
+        std::uintmax_t blockCount = 0;
+        if (!MultiplyWithin(blocksWide, blocksHigh, remaining, blockCount) ||
+            !MultiplyWithin(blockCount, layout.unit, remaining, levelBytes)) {
+            return false;
+        }
+    } else if (layout.storage == DdsStorage::PackedPairs) {
+        const auto pairsWide = (static_cast<std::uintmax_t>(width) + 1u) / 2u;
+        std::uintmax_t rowBytes = 0;
+        if (!MultiplyWithin(pairsWide, layout.unit, remaining, rowBytes) ||
+            !MultiplyWithin(rowBytes, height, remaining, levelBytes)) {
+            return false;
+        }
+    } else {
+        std::uintmax_t rowBits = 0;
+        if (!MultiplyWithin(width, layout.unit,
+                std::numeric_limits<std::uintmax_t>::max(), rowBits)) {
+            return false;
+        }
+        const auto rowBytes = rowBits / 8u + (rowBits % 8u != 0 ? 1u : 0u);
+        if (!MultiplyWithin(rowBytes, height, remaining, levelBytes)) return false;
+    }
+    if (levelBytes > remaining) return false;
+    required += levelBytes;
+    return true;
+}
+
+bool ValidateDds(const std::vector<std::uint8_t>& bytes, std::uint32_t maximumDimension,
+                 std::string& error) {
+    if (bytes.size() < 128 || !std::equal(kDdsMagic.begin(), kDdsMagic.end(), bytes.begin())) {
+        error = "DDS source has no valid DDS magic/header";
+        return false;
+    }
+    const auto headerSize = ReadU32(bytes, 4);
+    const auto height = ReadU32(bytes, 12);
+    const auto width = ReadU32(bytes, 16);
+    const auto depth = ReadU32(bytes, 24);
+    auto mipCount = ReadU32(bytes, 28);
+    const auto pixelFormatSize = ReadU32(bytes, 76);
+    if (headerSize != 124 || pixelFormatSize != 32 || width == 0 || height == 0 ||
+        width > maximumDimension || height > maximumDimension) {
+        error = "DDS header or dimensions are invalid";
+        return false;
+    }
+    const auto caps2 = ReadU32(bytes, 112);
+    constexpr std::uint32_t unsupportedLegacyResources = 0x0000FE00u | 0x00200000u;
+    if (depth > 1 || (caps2 & unsupportedLegacyResources) != 0) {
+        error = "DDS arrays, cube maps and volume textures are not valid material maps";
+        return false;
+    }
+
+    if (mipCount == 0) mipCount = 1;
+    std::uint32_t maximumMipCount = 1;
+    for (auto dimension = std::max(width, height); dimension > 1; dimension /= 2) {
+        ++maximumMipCount;
+    }
+    if (mipCount > maximumMipCount) {
+        error = "DDS mip count exceeds the declared dimensions";
+        return false;
+    }
+
+    constexpr std::uint32_t ddpfFourCc = 0x4u;
+    constexpr std::uint32_t ddpfAlphaPixels = 0x1u;
+    constexpr std::uint32_t ddpfAlpha = 0x2u;
+    constexpr std::uint32_t ddpfRgb = 0x40u;
+    constexpr std::uint32_t ddpfLuminance = 0x20000u;
+    constexpr std::uint32_t ddpfBumpDuDv = 0x80000u;
+    constexpr std::uint32_t ddpfUncompressedPrimary =
+        ddpfAlpha | ddpfRgb | ddpfLuminance | ddpfBumpDuDv;
+    const auto pixelFlags = ReadU32(bytes, 80);
+    const auto fourCc = ReadU32(bytes, 84);
+    std::size_t dataOffset = 128;
+    std::optional<DdsLayout> layout;
+    if ((pixelFlags & ddpfFourCc) != 0) {
+        if (fourCc == FourCc('D', 'X', '1', '0')) {
+            if (bytes.size() < 148) {
+                error = "DDS DX10 header is truncated";
+                return false;
+            }
+            const auto dxgiFormat = ReadU32(bytes, 128);
+            const auto resourceDimension = ReadU32(bytes, 132);
+            const auto miscFlag = ReadU32(bytes, 136);
+            const auto arraySize = ReadU32(bytes, 140);
+            if (resourceDimension != 3 || arraySize != 1 || (miscFlag & 0x4u) != 0) {
+                error = "DDS arrays, cube maps and non-2D resources are not valid material maps";
+                return false;
+            }
+            layout = DxgiLayout(dxgiFormat);
+            dataOffset = 148;
+        } else {
+            layout = LegacyFourCcLayout(fourCc);
+        }
+    } else if ((pixelFlags & ddpfUncompressedPrimary) != 0) {
+        const auto primaryFlags = pixelFlags & ddpfUncompressedPrimary;
+        const auto bitsPerPixel = ReadU32(bytes, 88);
+        const auto redMask = ReadU32(bytes, 92);
+        const auto greenMask = ReadU32(bytes, 96);
+        const auto blueMask = ReadU32(bytes, 100);
+        const auto alphaMask = ReadU32(bytes, 104);
+        const bool onePrimaryFlag = (primaryFlags & (primaryFlags - 1u)) == 0;
+        const bool supportedBits = bitsPerPixel == 8 || bitsPerPixel == 16 ||
+            bitsPerPixel == 24 || bitsPerPixel == 32 || bitsPerPixel == 64 ||
+            bitsPerPixel == 128;
+        const bool primaryMaskPresent = primaryFlags == ddpfAlpha
+            ? alphaMask != 0
+            : (redMask | greenMask | blueMask) != 0;
+        bool masksFit = true;
+        if (bitsPerPixel < 32) {
+            const auto allowedMask = (std::uint32_t{1} << bitsPerPixel) - 1u;
+            masksFit = ((redMask | greenMask | blueMask | alphaMask) & ~allowedMask) == 0;
+        }
+        const bool masksDisjoint = (redMask & greenMask) == 0 &&
+            (redMask & blueMask) == 0 && (redMask & alphaMask) == 0 &&
+            (greenMask & blueMask) == 0 && (greenMask & alphaMask) == 0 &&
+            (blueMask & alphaMask) == 0;
+        const bool alphaFlagConsistent = (pixelFlags & ddpfAlphaPixels) != 0 ||
+            alphaMask == 0 || primaryFlags == ddpfAlpha;
+        if (onePrimaryFlag && supportedBits && primaryMaskPresent && masksFit &&
+            masksDisjoint && alphaFlagConsistent) {
+            layout = DdsLayout{DdsStorage::BitsPerPixel, bitsPerPixel};
+        }
+    }
+    if (!layout) {
+        error = "DDS pixel format is unsupported or malformed";
+        return false;
+    }
+
+    std::uintmax_t required = dataOffset;
+    auto mipWidth = width;
+    auto mipHeight = height;
+    for (std::uint32_t level = 0; level < mipCount; ++level) {
+        if (!AddDdsMipBytes(*layout, mipWidth, mipHeight, required, bytes.size())) {
+            error = "DDS pixel or mip payload is truncated";
+            return false;
+        }
+        mipWidth = std::max(1u, mipWidth / 2u);
+        mipHeight = std::max(1u, mipHeight / 2u);
+    }
+    return true;
+}
+
+bool IsWicExtension(const std::string& extension) {
+    static constexpr std::array<const char*, 7> supported{
+        ".png", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff", ".gif"};
+    return std::find(supported.begin(), supported.end(), extension) != supported.end();
+}
+
+std::uint64_t Fnv1a(const std::vector<std::uint8_t>& bytes,
+                    const std::vector<TextureOperation>& operations) {
+    std::uint64_t hash = 14695981039346656037ull;
+    const auto add = [&hash](const void* data, std::size_t size) {
+        const auto* cursor = static_cast<const std::uint8_t*>(data);
+        for (std::size_t index = 0; index < size; ++index) {
+            hash ^= cursor[index];
+            hash *= 1099511628211ull;
+        }
+    };
+    add(bytes.data(), bytes.size());
+    for (const auto& operation : operations) {
+        const auto kind = static_cast<std::uint8_t>(operation.kind);
+        add(&kind, sizeof(kind));
+        add(&operation.color, sizeof(operation.color));
+        add(&operation.strength, sizeof(operation.strength));
+        const auto channel = static_cast<std::uint8_t>(operation.channel);
+        add(&channel, sizeof(channel));
+    }
+    return hash;
+}
+
+std::string Hex(std::uint64_t value) {
+    std::ostringstream output;
+    output << std::uppercase << std::hex << std::setfill('0') << std::setw(16) << value;
+    return output.str();
+}
+
+#ifdef _WIN32
+struct Image {
+    std::uint32_t width = 0;
+    std::uint32_t height = 0;
+    std::vector<std::uint8_t> bgra;
+};
+
+void ApplyOperations(Image& image, const std::vector<TextureOperation>& operations) {
+    for (const auto& operation : operations) {
+        if (operation.kind == TextureOperationKind::Invert) {
+            for (std::size_t offset = 0; offset < image.bgra.size(); offset += 4) {
+                image.bgra[offset + 0] = static_cast<std::uint8_t>(255 - image.bgra[offset + 0]);
+                image.bgra[offset + 1] = static_cast<std::uint8_t>(255 - image.bgra[offset + 1]);
+                image.bgra[offset + 2] = static_cast<std::uint8_t>(255 - image.bgra[offset + 2]);
+            }
+        } else if (operation.kind == TextureOperationKind::Multiply) {
+            for (std::size_t offset = 0; offset < image.bgra.size(); offset += 4) {
+                image.bgra[offset + 0] = static_cast<std::uint8_t>(std::clamp(
+                    image.bgra[offset + 0] * operation.color.z, 0.0f, 255.0f));
+                image.bgra[offset + 1] = static_cast<std::uint8_t>(std::clamp(
+                    image.bgra[offset + 1] * operation.color.y, 0.0f, 255.0f));
+                image.bgra[offset + 2] = static_cast<std::uint8_t>(std::clamp(
+                    image.bgra[offset + 2] * operation.color.x, 0.0f, 255.0f));
+            }
+        } else if (operation.kind == TextureOperationKind::NormalFromHeight) {
+            const auto source = image.bgra;
+            const auto heightSample = [&source, &image, &operation](int x, int y) {
+                x = std::clamp(x, 0, static_cast<int>(image.width) - 1);
+                y = std::clamp(y, 0, static_cast<int>(image.height) - 1);
+                const auto offset = (static_cast<std::size_t>(y) * image.width +
+                                     static_cast<std::size_t>(x)) * 4;
+                switch (operation.channel) {
+                case HeightChannel::Red: return source[offset + 2] / 255.0f;
+                case HeightChannel::Green: return source[offset + 1] / 255.0f;
+                case HeightChannel::Blue: return source[offset + 0] / 255.0f;
+                case HeightChannel::Alpha: return source[offset + 3] / 255.0f;
+                case HeightChannel::Luminance:
+                default:
+                    return (source[offset + 2] * 0.2126f + source[offset + 1] * 0.7152f +
+                            source[offset + 0] * 0.0722f) / 255.0f;
+                }
+            };
+            for (std::uint32_t y = 0; y < image.height; ++y) {
+                for (std::uint32_t x = 0; x < image.width; ++x) {
+                    const int ix = static_cast<int>(x);
+                    const int iy = static_cast<int>(y);
+                    const float gx =
+                        -heightSample(ix - 1, iy - 1) - 2.0f * heightSample(ix - 1, iy) -
+                        heightSample(ix - 1, iy + 1) + heightSample(ix + 1, iy - 1) +
+                        2.0f * heightSample(ix + 1, iy) + heightSample(ix + 1, iy + 1);
+                    const float gy =
+                        -heightSample(ix - 1, iy - 1) - 2.0f * heightSample(ix, iy - 1) -
+                        heightSample(ix + 1, iy - 1) + heightSample(ix - 1, iy + 1) +
+                        2.0f * heightSample(ix, iy + 1) + heightSample(ix + 1, iy + 1);
+                    float nx = -gx * operation.strength;
+                    float ny = -gy * operation.strength;
+                    float nz = 1.0f;
+                    const float inverseLength = 1.0f / std::sqrt(nx * nx + ny * ny + nz * nz);
+                    nx *= inverseLength;
+                    ny *= inverseLength;
+                    nz *= inverseLength;
+                    const auto offset = (static_cast<std::size_t>(y) * image.width + x) * 4;
+                    image.bgra[offset + 0] = static_cast<std::uint8_t>((nz * 0.5f + 0.5f) * 255.0f);
+                    image.bgra[offset + 1] = static_cast<std::uint8_t>((ny * 0.5f + 0.5f) * 255.0f);
+                    image.bgra[offset + 2] = static_cast<std::uint8_t>((nx * 0.5f + 0.5f) * 255.0f);
+                    image.bgra[offset + 3] = 255;
+                }
+            }
+        }
+    }
+}
+
+#pragma pack(push, 1)
+struct DdsPixelFormat {
+    std::uint32_t size;
+    std::uint32_t flags;
+    std::uint32_t fourCc;
+    std::uint32_t rgbBitCount;
+    std::uint32_t redMask;
+    std::uint32_t greenMask;
+    std::uint32_t blueMask;
+    std::uint32_t alphaMask;
+};
+
+struct DdsHeader {
+    std::uint32_t size;
+    std::uint32_t flags;
+    std::uint32_t height;
+    std::uint32_t width;
+    std::uint32_t pitch;
+    std::uint32_t depth;
+    std::uint32_t mipMapCount;
+    std::uint32_t reserved[11];
+    DdsPixelFormat pixelFormat;
+    std::uint32_t caps;
+    std::uint32_t caps2;
+    std::uint32_t caps3;
+    std::uint32_t caps4;
+    std::uint32_t reserved2;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(DdsHeader) == 124, "DDS header layout must be 124 bytes");
+
+std::vector<std::uint8_t> EncodeDds(Image image, bool normalizeNormalMips) {
+    std::uint32_t mipCount = 1;
+    for (auto dimension = std::max(image.width, image.height); dimension > 1; dimension /= 2) {
+        ++mipCount;
+    }
+
+    DdsHeader header{};
+    header.size = 124;
+    header.flags = 0x1u | 0x2u | 0x4u | 0x8u | 0x1000u | 0x20000u;
+    header.height = image.height;
+    header.width = image.width;
+    header.pitch = image.width * 4u;
+    header.depth = 1;
+    header.mipMapCount = mipCount;
+    header.pixelFormat = {32, 0x1u | 0x40u, 0, 32,
+                          0x00ff0000u, 0x0000ff00u, 0x000000ffu, 0xff000000u};
+    header.caps = 0x1000u | 0x8u | 0x400000u;
+
+    std::vector<std::uint8_t> output;
+    output.reserve(128 + image.bgra.size() * 4 / 3 + 64);
+    output.insert(output.end(), kDdsMagic.begin(), kDdsMagic.end());
+    const auto* headerBytes = reinterpret_cast<const std::uint8_t*>(&header);
+    output.insert(output.end(), headerBytes, headerBytes + sizeof(header));
+
+    auto current = std::move(image.bgra);
+    auto width = image.width;
+    auto height = image.height;
+    output.insert(output.end(), current.begin(), current.end());
+    while (width > 1 || height > 1) {
+        const auto nextWidth = std::max(1u, width / 2u);
+        const auto nextHeight = std::max(1u, height / 2u);
+        std::vector<std::uint8_t> next(static_cast<std::size_t>(nextWidth) * nextHeight * 4u);
+        for (std::uint32_t y = 0; y < nextHeight; ++y) {
+            for (std::uint32_t x = 0; x < nextWidth; ++x) {
+                std::uint32_t sums[4]{};
+                std::uint32_t samples = 0;
+                for (std::uint32_t dy = 0; dy < 2 && y * 2 + dy < height; ++dy) {
+                    for (std::uint32_t dx = 0; dx < 2 && x * 2 + dx < width; ++dx) {
+                        const auto sourceOffset =
+                            (static_cast<std::size_t>(y * 2 + dy) * width + x * 2 + dx) * 4;
+                        for (int channel = 0; channel < 4; ++channel) {
+                            sums[channel] += current[sourceOffset + channel];
+                        }
+                        ++samples;
+                    }
+                }
+                const auto destinationOffset =
+                    (static_cast<std::size_t>(y) * nextWidth + x) * 4;
+                for (int channel = 0; channel < 4; ++channel) {
+                    next[destinationOffset + channel] =
+                        static_cast<std::uint8_t>(sums[channel] / samples);
+                }
+                if (normalizeNormalMips) {
+                    float nx = next[destinationOffset + 2] / 127.5f - 1.0f;
+                    float ny = next[destinationOffset + 1] / 127.5f - 1.0f;
+                    float nz = next[destinationOffset + 0] / 127.5f - 1.0f;
+                    const float lengthSquared = nx * nx + ny * ny + nz * nz;
+                    if (lengthSquared > 1.0e-12f) {
+                        const float inverseLength = 1.0f / std::sqrt(lengthSquared);
+                        nx *= inverseLength;
+                        ny *= inverseLength;
+                        nz *= inverseLength;
+                    } else {
+                        nx = 0.0f;
+                        ny = 0.0f;
+                        nz = 1.0f;
+                    }
+                    const auto encodeComponent = [](float value) {
+                        const float encoded = std::clamp(
+                            (value * 0.5f + 0.5f) * 255.0f, 0.0f, 255.0f);
+                        return static_cast<std::uint8_t>(encoded + 0.5f);
+                    };
+                    next[destinationOffset + 0] = encodeComponent(nz);
+                    next[destinationOffset + 1] = encodeComponent(ny);
+                    next[destinationOffset + 2] = encodeComponent(nx);
+                }
+            }
+        }
+        output.insert(output.end(), next.begin(), next.end());
+        current = std::move(next);
+        width = nextWidth;
+        height = nextHeight;
+    }
+    return output;
+}
+
+template <typename T>
+class ComObject {
+public:
+    ~ComObject() { if (value_) value_->Release(); }
+    T** Put() { return &value_; }
+    T* Get() const { return value_; }
+    T* operator->() const { return value_; }
+private:
+    T* value_ = nullptr;
+};
+
+class ComApartment {
+public:
+    ComApartment() : result_(CoInitializeEx(nullptr, COINIT_MULTITHREADED)),
+                     owns_(result_ == S_OK || result_ == S_FALSE) {}
+    ~ComApartment() { if (owns_) CoUninitialize(); }
+    HRESULT Result() const { return result_; }
+private:
+    HRESULT result_;
+    bool owns_;
+};
+
+bool DecodeWithWic(const std::filesystem::path& path, std::uint32_t maximumDimension,
+                   std::uintmax_t maximumBytes,
+                   Image& image, std::string& error) {
+    ComApartment apartment;
+    if (FAILED(apartment.Result()) && apartment.Result() != RPC_E_CHANGED_MODE) {
+        error = "COM initialization failed";
+        return false;
+    }
+
+    ComObject<IWICImagingFactory> factory;
+    HRESULT result = CoCreateInstance(CLSID_WICImagingFactory, nullptr,
+        CLSCTX_INPROC_SERVER, IID_PPV_ARGS(factory.Put()));
+    ComObject<IWICBitmapDecoder> decoder;
+    ComObject<IWICBitmapFrameDecode> frame;
+    ComObject<IWICFormatConverter> converter;
+    if (SUCCEEDED(result)) {
+        result = factory->CreateDecoderFromFilename(path.c_str(), nullptr, GENERIC_READ,
+            WICDecodeMetadataCacheOnLoad, decoder.Put());
+    }
+    if (SUCCEEDED(result)) result = decoder->GetFrame(0, frame.Put());
+    if (SUCCEEDED(result)) result = factory->CreateFormatConverter(converter.Put());
+    if (SUCCEEDED(result)) {
+        result = converter->Initialize(frame.Get(), GUID_WICPixelFormat32bppBGRA,
+            WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom);
+    }
+    UINT width = 0;
+    UINT height = 0;
+    if (SUCCEEDED(result)) result = converter->GetSize(&width, &height);
+    std::uintmax_t encodedBytes = 128;
+    if (SUCCEEDED(result) && (width == 0 || height == 0 || width > maximumDimension ||
+                              height > maximumDimension)) {
+        result = E_INVALIDARG;
+        error = "decoded texture dimensions exceed the configured safety limit";
+    }
+    if (SUCCEEDED(result)) {
+        auto mipWidth = static_cast<std::uintmax_t>(width);
+        auto mipHeight = static_cast<std::uintmax_t>(height);
+        while (true) {
+            const auto rowBytes = mipWidth * 4u;
+            if (encodedBytes > maximumBytes || rowBytes > maximumBytes ||
+                mipHeight > (maximumBytes - encodedBytes) / rowBytes) {
+                result = E_INVALIDARG;
+                error = "decoded texture mip chain exceeds the configured safety limit";
+                break;
+            }
+            encodedBytes += rowBytes * mipHeight;
+            if (mipWidth == 1 && mipHeight == 1) break;
+            mipWidth = std::max<std::uintmax_t>(1, mipWidth / 2);
+            mipHeight = std::max<std::uintmax_t>(1, mipHeight / 2);
+        }
+    }
+    if (SUCCEEDED(result)) {
+        const auto rowBytes = static_cast<std::uintmax_t>(width) * 4u;
+        const auto baseBytes = rowBytes * height;
+        if (rowBytes > std::numeric_limits<UINT>::max() ||
+            baseBytes > std::numeric_limits<UINT>::max()) {
+            result = E_INVALIDARG;
+            error = "decoded texture exceeds the Windows decoder buffer limit";
+        }
+    }
+    if (SUCCEEDED(result)) {
+        image.width = width;
+        image.height = height;
+        image.bgra.resize(static_cast<std::size_t>(width) * height * 4u);
+        result = converter->CopyPixels(nullptr, width * 4u,
+            static_cast<UINT>(image.bgra.size()), image.bgra.data());
+    }
+    if (FAILED(result)) {
+        if (error.empty()) {
+            error = "Windows Imaging Component could not decode the texture (HRESULT " +
+                std::to_string(static_cast<unsigned long>(result)) + ")";
+        }
+        return false;
+    }
+    return true;
+}
+#endif
+
+} // namespace
+
+bool SupportsWicConversion() noexcept {
+#ifdef _WIN32
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool SupportsTextureOperations() noexcept {
+    return SupportsWicConversion();
+}
+
+Result ImportTexture(const TextureImportConfig& config,
+                     const std::string& profileId,
+                     const TextureInput& input,
+                     ImportedTexture& output) {
+    std::error_code ec;
+    std::filesystem::path source = input.source;
+    if (source.is_relative()) {
+        // The Lua file API commonly reports paths relative to garrysmod/ or
+        // garrysmod/data/. Resolve only these well-known in-install locations.
+        const auto& gameRoot = config.gameRoot;
+        const std::filesystem::path candidates[]{
+            gameRoot / source,
+            gameRoot / "garrysmod" / source,
+            gameRoot / "garrysmod" / "data" / source,
+        };
+        for (const auto& candidate : candidates) {
+            if (std::filesystem::is_regular_file(candidate, ec)) {
+                source = candidate;
+                break;
+            }
+            ec.clear();
+        }
+    }
+    const auto canonicalSource = std::filesystem::canonical(source, ec);
+    if (ec || !std::filesystem::is_regular_file(canonicalSource, ec)) {
+        return Result::Failure("invalid_texture_path", "texture source is not a readable regular file");
+    }
+
+    bool allowed = false;
+    for (const auto& root : config.allowedRoots) {
+        if (IsDescendantOrSame(canonicalSource, root)) {
+            allowed = true;
+            break;
+        }
+    }
+    if (!allowed) {
+        return Result::Failure("texture_path_outside_allowed_roots",
+            "texture source resolves outside the configured import roots");
+    }
+
+    // ~gmod_topbr belongs to the client's ToPBR pipeline.  Even though it is
+    // below the broad default game-root import boundary, never let this addon
+    // read or derive assets from another writer's managed output tree.
+    std::error_code protectedEc;
+    const auto protectedRoot = std::filesystem::canonical(
+        config.gameRoot / "rtx-remix" / "mods" / "~gmod_topbr", protectedEc);
+    if (!protectedEc && IsDescendantOrSame(canonicalSource, protectedRoot)) {
+        return Result::Failure("protected_texture_path",
+            "texture source is inside the protected ~gmod_topbr output tree");
+    }
+
+    const auto extension = Lowercase(canonicalSource.extension().string());
+    const bool isDds = extension == ".dds";
+    if (!isDds && !IsWicExtension(extension)) {
+        return Result::Failure("unsupported_texture_format",
+            "only DDS and Windows Imaging Component formats are accepted");
+    }
+#ifndef _WIN32
+    if (!isDds) {
+        return Result::Failure("texture_conversion_unavailable",
+            "this build can only import existing DDS files");
+    }
+#endif
+
+    std::vector<std::uint8_t> sourceBytes;
+    std::string error;
+    if (!ReadFile(canonicalSource, config.maxBytes, sourceBytes, error)) {
+        return Result::Failure("texture_read_failed", error);
+    }
+    if (isDds) {
+        if (!input.operations.empty()) {
+            return Result::Failure("dds_bake_unsupported",
+                "bake operations require a WIC-decodable source such as PNG; compressed DDS editing is not supported");
+        }
+        if (!ValidateDds(sourceBytes, config.maxDimension, error)) {
+            return Result::Failure("invalid_dds", error);
+        }
+    }
+
+    // Derive and validate the content-addressed destination before decoding.
+    // An unchanged generated image therefore costs one bounded source read and
+    // hash, but no WIC decode, bake pass, mip generation, or file rewrite.
+    const auto digest = Hex(Fnv1a(sourceBytes, input.operations));
+    const std::string filename = std::string(TextureRoleName(input.role)) + "_" + digest + ".dds";
+    const auto destination = config.modDirectory / "textures" / profileId / filename;
+    if (!IsDescendantOrSame(destination, config.modDirectory)) {
+        return Result::Failure("unsafe_texture_destination", "computed texture destination escaped the mod directory");
+    }
+    bool runtimeExists = false;
+    if (!InspectPlainPath(config.gameRoot / "rtx-remix", true,
+                          runtimeExists, error) || !runtimeExists) {
+        if (error.empty()) error = "rtx-remix runtime directory is missing";
+        return Result::Failure("unsafe_texture_destination", error);
+    }
+    const auto destinationDirectory = destination.parent_path();
+    if (!EnsurePlainDirectoryTree(config.gameRoot, destinationDirectory, error)) {
+        return Result::Failure("unsafe_texture_destination", error);
+    }
+    bool destinationExists = false;
+    if (!InspectPlainPath(destination, false, destinationExists, error)) {
+        return Result::Failure("unsafe_texture_destination", error);
+    }
+    output.role = input.role;
+    output.absolutePath = destination;
+    output.layerAssetPath = "../textures/" + profileId + "/" + filename;
+    if (destinationExists) {
+        std::vector<std::uint8_t> cachedBytes;
+        std::string cacheError;
+        const bool validCache = ReadFile(
+            destination, config.maxBytes, cachedBytes, cacheError) &&
+            ValidateDds(cachedBytes, config.maxDimension, cacheError);
+        // For a direct DDS import the content-address key is a digest of these
+        // exact bytes, so a structurally valid but altered cache file must not
+        // be trusted. WIC-derived output has no cheap expected byte stream and
+        // is still protected by full structural validation.
+        if (validCache && (!isDds || cachedBytes == sourceBytes)) {
+            output.changed = false;
+            return Result::Success(profileId);
+        }
+    }
+
+    std::vector<std::uint8_t> ddsBytes;
+    if (isDds) {
+        ddsBytes = std::move(sourceBytes);
+    } else {
+#ifdef _WIN32
+        Image image;
+        if (!DecodeWithWic(canonicalSource, config.maxDimension, config.maxBytes, image, error)) {
+            return Result::Failure("texture_decode_failed", error);
+        }
+        ApplyOperations(image, input.operations);
+        ddsBytes = EncodeDds(std::move(image), input.role == TextureRole::Normal);
+#else
+        return Result::Failure("texture_conversion_unavailable", "unreachable conversion path");
+#endif
+    }
+
+    if (!ValidatePlainDirectoryTree(config.gameRoot, destinationDirectory, error) ||
+        !InspectPlainPath(destination, false, destinationExists, error)) {
+        return Result::Failure("unsafe_texture_destination", error);
+    }
+    if (!AtomicWriteBytes(destination, ddsBytes, error)) {
+        return Result::Failure("texture_write_failed", error);
+    }
+    output.changed = true;
+    return Result::Success(profileId);
+}
+
+} // namespace advmat::rtx_bridge::detail

--- a/source/advmat_rtx_bridge/src/usda_writer.cpp
+++ b/source/advmat_rtx_bridge/src/usda_writer.cpp
@@ -1,0 +1,348 @@
+#include "internal.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iterator>
+#include <locale>
+#include <map>
+#include <sstream>
+
+namespace advmat::rtx_bridge::detail {
+namespace {
+
+bool InRange(const std::optional<float>& value, float minimum, float maximum,
+             const char* name, std::string& error) {
+    if (!value) {
+        return true;
+    }
+    if (!std::isfinite(*value) || *value < minimum || *value > maximum) {
+        error = std::string(name) + " must be finite and in [" +
+            std::to_string(minimum) + ", " + std::to_string(maximum) + "]";
+        return false;
+    }
+    return true;
+}
+
+bool VecInRange(const std::optional<Vec3>& value, float minimum, float maximum,
+                const char* name, std::string& error) {
+    if (!value) {
+        return true;
+    }
+    if (!std::isfinite(value->x) || !std::isfinite(value->y) || !std::isfinite(value->z) ||
+        value->x < minimum || value->x > maximum ||
+        value->y < minimum || value->y > maximum ||
+        value->z < minimum || value->z > maximum) {
+        error = std::string(name) + " components must be finite and in [" +
+            std::to_string(minimum) + ", " + std::to_string(maximum) + "]";
+        return false;
+    }
+    return true;
+}
+
+bool IntInRange(const std::optional<int>& value, int minimum, int maximum,
+                const char* name, std::string& error) {
+    if (value && (*value < minimum || *value > maximum)) {
+        error = std::string(name) + " must be in [" + std::to_string(minimum) +
+            ", " + std::to_string(maximum) + "]";
+        return false;
+    }
+    return true;
+}
+
+template <std::size_t Size>
+bool IntInSet(const std::optional<int>& value, const int (&allowed)[Size],
+              const char* name, std::string& error) {
+    if (value && std::find(std::begin(allowed), std::end(allowed), *value) ==
+                     std::end(allowed)) {
+        error = std::string(name) + " is not a supported enum value";
+        return false;
+    }
+    return true;
+}
+
+void Float(std::ostream& output, float value) {
+    // max_digits10 avoids locale-dependent output and preserves the authored
+    // float without littering the layer with unnecessary trailing zeroes.
+    output << std::setprecision(9) << value;
+}
+
+void WriteFloat(std::ostream& output, const char* name,
+                const std::optional<float>& value) {
+    if (!value) {
+        return;
+    }
+    output << "                float inputs:" << name << " = ";
+    Float(output, *value);
+    output << "\n";
+}
+
+void WriteInt(std::ostream& output, const char* name,
+              const std::optional<int>& value) {
+    if (value) {
+        output << "                int inputs:" << name << " = " << *value << "\n";
+    }
+}
+
+void WriteBool(std::ostream& output, const char* name,
+               const std::optional<bool>& value) {
+    if (value) {
+        output << "                bool inputs:" << name << " = " << (*value ? 1 : 0) << "\n";
+    }
+}
+
+void WriteColor(std::ostream& output, const char* name,
+                const std::optional<Vec3>& value) {
+    if (!value) {
+        return;
+    }
+    output << "                color3f inputs:" << name << " = (";
+    Float(output, value->x);
+    output << ", ";
+    Float(output, value->y);
+    output << ", ";
+    Float(output, value->z);
+    output << ")\n";
+}
+
+const char* TextureInputName(TextureRole role) {
+    switch (role) {
+    case TextureRole::Albedo: return "diffuse_texture";
+    case TextureRole::Normal: return "normalmap_texture";
+    case TextureRole::Anisotropy: return "anisotropy_texture";
+    case TextureRole::Roughness: return "reflectionroughness_texture";
+    case TextureRole::Metallic: return "metallic_texture";
+    case TextureRole::Height: return "height_texture";
+    case TextureRole::Emissive: return "emissive_mask_texture";
+    case TextureRole::SubsurfaceTransmittance: return "subsurface_transmittance_texture";
+    case TextureRole::SubsurfaceThickness: return "subsurface_thickness_texture";
+    case TextureRole::SubsurfaceScattering: return "subsurface_single_scattering_texture";
+    case TextureRole::SubsurfaceRadius: return "subsurface_radius_texture";
+    }
+    return "diffuse_texture";
+}
+
+const char* TextureColorSpace(TextureRole role) {
+    return (role == TextureRole::Albedo || role == TextureRole::Emissive ||
+            role == TextureRole::SubsurfaceTransmittance ||
+            role == TextureRole::SubsurfaceScattering) ? "sRGB" : "raw";
+}
+
+void WriteShader(std::ostream& output, const MaterialParameters& material,
+                 const std::vector<ImportedTexture>& textures) {
+    output << "                uniform asset info:mdl:sourceAsset = @AperturePBR_Opacity.mdl@\n";
+    output << "                uniform token info:mdl:sourceAsset:subIdentifier = \"AperturePBR_Opacity\"\n";
+
+    if (material.preloadTextures) {
+        WriteBool(output, "preload_textures", material.preloadTextures);
+    } else if (!textures.empty()) {
+        // Protocol 1 requests predate an explicit preload flag. Preserve their
+        // safe eager-loading behaviour only when the caller did not own it.
+        // File replacements are not backed by Source's sampler-feedback stamp.
+        output << "                bool inputs:preload_textures = 1\n";
+    }
+    if (material.normalEncoding) {
+        WriteInt(output, "encoding", material.normalEncoding);
+    } else if (std::any_of(textures.begin(), textures.end(), [](const auto& texture) {
+        return texture.role == TextureRole::Normal;
+    })) {
+        // Older requests had no encoding field. Source and AdvMat-generated
+        // RGB normals use DirectX tangent space in AperturePBR_Normal.
+        output << "                int inputs:encoding = 2\n";
+    }
+    for (const auto& texture : textures) {
+        output << "                asset inputs:" << TextureInputName(texture.role)
+               << " = @" << texture.layerAssetPath << "@ (\n";
+        output << "                    colorSpace = \"" << TextureColorSpace(texture.role) << "\"\n";
+        output << "                )\n";
+    }
+
+    WriteColor(output, "diffuse_color_constant", material.albedo);
+    WriteFloat(output, "opacity_constant", material.opacity);
+    WriteFloat(output, "reflection_roughness_constant", material.roughness);
+    WriteFloat(output, "metallic_constant", material.metallic);
+    WriteColor(output, "emissive_color_constant", material.emissiveColor);
+    WriteFloat(output, "emissive_intensity", material.emissiveIntensity);
+    if (material.enableEmission) {
+        WriteBool(output, "enable_emission", material.enableEmission);
+    } else if (material.emissiveIntensity && *material.emissiveIntensity > 0.0f) {
+        // Compatibility with requests created before enable_emission existed.
+        output << "                bool inputs:enable_emission = 1\n";
+    }
+    WriteFloat(output, "anisotropy_constant", material.anisotropy);
+    const bool hasThinFilmThickness = material.thinFilmThickness &&
+        *material.thinFilmThickness > 0.0f;
+    if (material.enableThinFilm) {
+        WriteBool(output, "enable_thin_film", material.enableThinFilm);
+    } else if (hasThinFilmThickness ||
+        (material.alphaIsThinFilmThickness && *material.alphaIsThinFilmThickness)) {
+        // Compatibility with requests created before enable_thin_film existed.
+        output << "                bool inputs:enable_thin_film = 1\n";
+    }
+    if (hasThinFilmThickness) {
+        WriteFloat(output, "thin_film_thickness_constant", material.thinFilmThickness);
+    }
+    WriteFloat(output, "displace_in", material.displaceIn);
+    WriteFloat(output, "displace_out", material.displaceOut);
+    WriteColor(output, "subsurface_transmittance_color",
+               material.subsurfaceTransmittanceColor);
+    WriteFloat(output, "subsurface_measurement_distance",
+               material.subsurfaceMeasurementDistance);
+    WriteColor(output, "subsurface_single_scattering_albedo",
+               material.subsurfaceSingleScatteringAlbedo);
+    WriteFloat(output, "subsurface_volumetric_anisotropy",
+               material.subsurfaceVolumetricAnisotropy);
+    WriteBool(output, "subsurface_diffusion_profile",
+              material.subsurfaceDiffusionProfile);
+    WriteColor(output, "subsurface_radius", material.subsurfaceRadius);
+    WriteFloat(output, "subsurface_radius_scale", material.subsurfaceRadiusScale);
+    WriteFloat(output, "subsurface_max_sample_radius",
+               material.subsurfaceMaxSampleRadius);
+
+    WriteInt(output, "sprite_sheet_rows", material.spriteSheetRows);
+    WriteInt(output, "sprite_sheet_cols", material.spriteSheetColumns);
+    WriteInt(output, "sprite_sheet_fps", material.spriteSheetFps);
+    WriteInt(output, "filter_mode", material.filterMode);
+    WriteInt(output, "wrap_mode_u", material.wrapModeU);
+    WriteInt(output, "wrap_mode_v", material.wrapModeV);
+    WriteBool(output, "ignore_material", material.ignoreMaterial);
+    WriteBool(output, "thin_film_thickness_from_albedo_alpha",
+              material.alphaIsThinFilmThickness);
+    WriteBool(output, "use_legacy_alpha_state", material.useDrawCallAlphaState);
+    if (material.blendEnabled) {
+        WriteBool(output, "blend_enabled", material.blendEnabled);
+    } else if (material.blendType) {
+        // Compatibility with requests created before blend_enabled existed.
+        output << "                bool inputs:blend_enabled = 1\n";
+    }
+    WriteInt(output, "blend_type", material.blendType);
+    WriteBool(output, "inverted_blend", material.invertedBlend);
+    WriteInt(output, "alpha_test_type", material.alphaTestType);
+    WriteFloat(output, "alpha_test_reference_value", material.alphaReferenceValue);
+}
+
+} // namespace
+
+bool ValidateMaterial(const MaterialParameters& material, std::string& error) {
+    static constexpr int filterModes[]{0, 1};
+    static constexpr int wrapModes[]{0, 1, 2, 3};
+    static_assert(kTextureRoleCount ==
+                  static_cast<std::size_t>(TextureRole::SubsurfaceRadius) + 1);
+    if (material.textures.size() > kTextureRoleCount) {
+        error = "at most one texture per supported map role is allowed";
+        return false;
+    }
+    bool seenRoles[kTextureRoleCount]{};
+    for (const auto& texture : material.textures) {
+        const auto role = static_cast<std::size_t>(texture.role);
+        if (role >= kTextureRoleCount || seenRoles[role]) {
+            error = "texture map roles must be valid and unique";
+            return false;
+        }
+        seenRoles[role] = true;
+        if (texture.source.empty()) {
+            error = std::string(TextureRoleName(texture.role)) + " texture source is empty";
+            return false;
+        }
+        if (texture.operations.size() > kMaxTextureOperations) {
+            error = "a texture map cannot contain more than " +
+                std::to_string(kMaxTextureOperations) + " bake operations";
+            return false;
+        }
+        for (const auto& operation : texture.operations) {
+            if (!std::isfinite(operation.strength) || operation.strength < 0.0f ||
+                operation.strength > 64.0f ||
+                !std::isfinite(operation.color.x) || !std::isfinite(operation.color.y) ||
+                !std::isfinite(operation.color.z) || operation.color.x < 0.0f ||
+                operation.color.y < 0.0f || operation.color.z < 0.0f ||
+                operation.color.x > 16.0f || operation.color.y > 16.0f ||
+                operation.color.z > 16.0f) {
+                error = "texture bake operation values are outside the supported range";
+                return false;
+            }
+        }
+    }
+
+    return VecInRange(material.albedo, 0.0f, 1.0f, "albedo", error) &&
+        InRange(material.opacity, 0.0f, 1.0f, "opacity", error) &&
+        InRange(material.roughness, 0.0f, 1.0f, "roughness", error) &&
+        InRange(material.metallic, 0.0f, 1.0f, "metallic", error) &&
+        VecInRange(material.emissiveColor, 0.0f, 1.0f, "emissive color", error) &&
+        InRange(material.emissiveIntensity, 0.0f, 65504.0f, "emissive intensity", error) &&
+        InRange(material.anisotropy, -1.0f, 1.0f, "anisotropy", error) &&
+        InRange(material.thinFilmThickness, 0.0f, 1500.0f,
+                "thin film thickness", error) &&
+        InRange(material.displaceIn, 0.0f, 0.2f, "displace in", error) &&
+        InRange(material.displaceOut, 0.0f, 0.2f, "displace out", error) &&
+        VecInRange(material.subsurfaceTransmittanceColor, 0.0f, 1.0f,
+                   "subsurface transmittance color", error) &&
+        InRange(material.subsurfaceMeasurementDistance, 0.0f, 16.0f,
+                "subsurface measurement distance", error) &&
+        VecInRange(material.subsurfaceSingleScatteringAlbedo, 0.0f, 1.0f,
+                   "subsurface single scattering albedo", error) &&
+        InRange(material.subsurfaceVolumetricAnisotropy, -0.99f, 0.99f,
+                "subsurface volumetric anisotropy", error) &&
+        VecInRange(material.subsurfaceRadius, 0.0f, 1.0f,
+                   "subsurface radius", error) &&
+        InRange(material.subsurfaceRadiusScale, 0.0f, 1000.0f,
+                "subsurface radius scale", error) &&
+        InRange(material.subsurfaceMaxSampleRadius, 0.0f, 65504.0f,
+                "subsurface max sample radius", error) &&
+        IntInRange(material.spriteSheetRows, 1, 255, "sprite sheet rows", error) &&
+        IntInRange(material.spriteSheetColumns, 1, 255, "sprite sheet columns", error) &&
+        IntInRange(material.spriteSheetFps, 0, 255, "sprite sheet fps", error) &&
+        IntInSet(material.filterMode, filterModes, "filter mode", error) &&
+        IntInSet(material.wrapModeU, wrapModes, "wrap mode U", error) &&
+        IntInSet(material.wrapModeV, wrapModes, "wrap mode V", error) &&
+        IntInRange(material.normalEncoding, 0, 2, "normal encoding", error) &&
+        IntInRange(material.blendType, 0, 8, "blend type", error) &&
+        IntInRange(material.alphaTestType, 0, 7, "alpha test type", error) &&
+        InRange(material.alphaReferenceValue, 0.0f, 1.0f, "alpha reference value", error);
+}
+
+std::string BuildProfileLayer(const std::vector<std::string>& hashes,
+                              const MaterialParameters& material,
+                              const std::vector<ImportedTexture>& textures) {
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+    output << "#usda 1.0\n(\n    upAxis = \"Z\"\n)\n\n";
+    output << "over \"RootNode\"\n{\n    over \"Looks\"\n    {\n";
+    for (const auto& hash : hashes) {
+        output << "        over \"mat_" << hash << "\"\n";
+        output << "        {\n            over \"Shader\"\n            {\n";
+        WriteShader(output, material, textures);
+        output << "            }\n        }\n\n";
+    }
+    output << "    }\n}\n";
+    return output.str();
+}
+
+std::string BuildEmptyProfileLayer() {
+    return "#usda 1.0\n(\n    upAxis = \"Z\"\n)\n\n"
+           "over \"RootNode\"\n{\n    over \"Looks\"\n    {\n    }\n}\n";
+}
+
+std::string BuildModLayer(const std::vector<std::string>& profileIds) {
+    std::ostringstream output;
+    output << "#usda 1.0\n(\n";
+    output << "    customLayerData = {\n";
+    output << "        string lightspeed_game_name = \"Garry's Mod (x64)\"\n";
+    output << "        string lightspeed_layer_type = \"replacement\"\n";
+    output << "    }\n";
+    output << "    metersPerUnit = 0.01\n";
+    output << "    subLayers = [\n";
+    for (std::size_t index = 0; index < profileIds.size(); ++index) {
+        output << "        @./profiles/" << profileIds[index] << ".usda@";
+        if (index + 1 < profileIds.size()) {
+            output << ',';
+        }
+        output << "\n";
+    }
+    output << "    ]\n";
+    output << "    timeCodesPerSecond = 24\n";
+    output << "    upAxis = \"Z\"\n)\n";
+    return output.str();
+}
+
+} // namespace advmat::rtx_bridge::detail
+

--- a/source/advmat_rtx_bridge/tests/writer_tests.cpp
+++ b/source/advmat_rtx_bridge/tests/writer_tests.cpp
@@ -1,0 +1,1573 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include "advmat_rtx_bridge/bridge.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+using namespace advmat::rtx_bridge;
+
+namespace {
+
+std::string ReadText(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+void PutU32(std::vector<std::uint8_t>& bytes, std::size_t offset, std::uint32_t value) {
+    bytes[offset + 0] = static_cast<std::uint8_t>(value);
+    bytes[offset + 1] = static_cast<std::uint8_t>(value >> 8u);
+    bytes[offset + 2] = static_cast<std::uint8_t>(value >> 16u);
+    bytes[offset + 3] = static_cast<std::uint8_t>(value >> 24u);
+}
+
+void WriteMinimalDds(const std::filesystem::path& path,
+                     std::uint32_t width = 1, std::uint32_t height = 1,
+                     std::uint32_t mipMapCount = 1,
+                     std::optional<std::size_t> payloadBytes = std::nullopt,
+                     std::uint32_t pixelFlags = 0x1u | 0x40u) {
+    const auto pixelBytes = payloadBytes.value_or(
+        static_cast<std::size_t>(width) * height * 4u);
+    std::vector<std::uint8_t> bytes(128 + pixelBytes, 0);
+    bytes[0] = 'D'; bytes[1] = 'D'; bytes[2] = 'S'; bytes[3] = ' ';
+    PutU32(bytes, 4, 124);
+    PutU32(bytes, 8, 0x100Fu);
+    PutU32(bytes, 12, height);
+    PutU32(bytes, 16, width);
+    PutU32(bytes, 20, width * 4u);
+    PutU32(bytes, 24, 1);
+    PutU32(bytes, 28, mipMapCount);
+    PutU32(bytes, 76, 32);
+    PutU32(bytes, 80, pixelFlags);
+    PutU32(bytes, 88, 32);
+    PutU32(bytes, 92, 0x00ff0000u);
+    PutU32(bytes, 96, 0x0000ff00u);
+    PutU32(bytes, 100, 0x000000ffu);
+    PutU32(bytes, 104, 0xff000000u);
+    PutU32(bytes, 108, 0x1000u);
+    constexpr std::uint8_t pixel[]{0x10, 0x20, 0x30, 0xff};
+    for (std::size_t offset = 128; offset < bytes.size(); ++offset) {
+        bytes[offset] = pixel[(offset - 128) % 4];
+    }
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+}
+
+constexpr std::uint32_t TestFourCc(char a, char b, char c, char d) {
+    return static_cast<std::uint32_t>(static_cast<unsigned char>(a)) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(b)) << 8u) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(c)) << 16u) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(d)) << 24u);
+}
+
+void WriteLegacyFourCcDds(const std::filesystem::path& path,
+                          std::uint32_t fourCc, std::uint32_t width,
+                          std::uint32_t height, std::uint32_t mipMapCount,
+                          std::size_t payloadBytes) {
+    std::vector<std::uint8_t> bytes(128 + payloadBytes, 0);
+    bytes[0] = 'D'; bytes[1] = 'D'; bytes[2] = 'S'; bytes[3] = ' ';
+    PutU32(bytes, 4, 124);
+    PutU32(bytes, 12, height);
+    PutU32(bytes, 16, width);
+    PutU32(bytes, 24, 1);
+    PutU32(bytes, 28, mipMapCount);
+    PutU32(bytes, 76, 32);
+    PutU32(bytes, 80, 0x4u);
+    PutU32(bytes, 84, fourCc);
+    PutU32(bytes, 108, 0x1000u);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+}
+
+void WriteMalformedDx10Dds(const std::filesystem::path& path) {
+    std::vector<std::uint8_t> bytes(128, 0);
+    bytes[0] = 'D'; bytes[1] = 'D'; bytes[2] = 'S'; bytes[3] = ' ';
+    PutU32(bytes, 4, 124);
+    PutU32(bytes, 12, 4);
+    PutU32(bytes, 16, 4);
+    PutU32(bytes, 24, 1);
+    PutU32(bytes, 28, 1);
+    PutU32(bytes, 76, 32);
+    PutU32(bytes, 80, 0x4u);
+    PutU32(bytes, 84, static_cast<std::uint32_t>('D') |
+        (static_cast<std::uint32_t>('X') << 8u) |
+        (static_cast<std::uint32_t>('1') << 16u) |
+        (static_cast<std::uint32_t>('0') << 24u));
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+}
+
+void WriteDx10Bc7Dds(const std::filesystem::path& path) {
+    std::vector<std::uint8_t> bytes(148 + 16, 0);
+    bytes[0] = 'D'; bytes[1] = 'D'; bytes[2] = 'S'; bytes[3] = ' ';
+    PutU32(bytes, 4, 124);
+    PutU32(bytes, 12, 4);
+    PutU32(bytes, 16, 4);
+    PutU32(bytes, 24, 1);
+    PutU32(bytes, 28, 1);
+    PutU32(bytes, 76, 32);
+    PutU32(bytes, 80, 0x4u);
+    PutU32(bytes, 84, static_cast<std::uint32_t>('D') |
+        (static_cast<std::uint32_t>('X') << 8u) |
+        (static_cast<std::uint32_t>('1') << 16u) |
+        (static_cast<std::uint32_t>('0') << 24u));
+    PutU32(bytes, 128, 98); // DXGI_FORMAT_BC7_UNORM
+    PutU32(bytes, 132, 3); // D3D10_RESOURCE_DIMENSION_TEXTURE2D
+    PutU32(bytes, 140, 1);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+}
+
+#ifdef _WIN32
+void PutU16(std::vector<std::uint8_t>& bytes, std::size_t offset, std::uint16_t value) {
+    bytes[offset + 0] = static_cast<std::uint8_t>(value);
+    bytes[offset + 1] = static_cast<std::uint8_t>(value >> 8u);
+}
+
+void WriteNormalMipFixture(const std::filesystem::path& path) {
+    // A 2x2 BGRA BMP containing two +X and two +Z normals. Their raw box
+    // average is length ~0.71; the generated 1x1 mip must be renormalized.
+    std::vector<std::uint8_t> bytes(70, 0);
+    bytes[0] = 'B';
+    bytes[1] = 'M';
+    PutU32(bytes, 2, static_cast<std::uint32_t>(bytes.size()));
+    PutU32(bytes, 10, 54);
+    PutU32(bytes, 14, 40);
+    PutU32(bytes, 18, 2);
+    PutU32(bytes, 22, 2);
+    PutU16(bytes, 26, 1);
+    PutU16(bytes, 28, 32);
+    PutU32(bytes, 34, 16);
+    const std::uint8_t pixels[]{
+        128, 128, 255, 255, 255, 128, 128, 255,
+        128, 128, 255, 255, 255, 128, 128, 255,
+    };
+    std::copy(std::begin(pixels), std::end(pixels), bytes.begin() + 54);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary);
+    output.write(reinterpret_cast<const char*>(bytes.data()),
+                 static_cast<std::streamsize>(bytes.size()));
+}
+#endif
+
+void WriteText(const std::filesystem::path& path, const std::string& contents) {
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output << contents;
+}
+
+std::string LegacyLayer(const std::vector<std::string>& hashes) {
+    std::string output = "#usda 1.0\n(\n    upAxis = \"Z\"\n)\n\n"
+                         "over \"RootNode\"\n{\n    over \"Looks\"\n    {\n";
+    for (const auto& hash : hashes) {
+        output += "        over \"mat_" + hash + "\"\n"
+                  "        {\n            over \"Shader\"\n            {\n"
+                  "                uniform asset info:mdl:sourceAsset = @AperturePBR_Opacity.mdl@\n"
+                  "                float inputs:reflection_roughness_constant = 0.5\n"
+                  "            }\n        }\n\n";
+    }
+    output += "    }\n}\n";
+    return output;
+}
+
+std::string ModLayer(const std::vector<std::string>& profileIds) {
+    std::string output = "#usda 1.0\n(\n"
+                         "    customLayerData = {\n"
+                         "        string lightspeed_game_name = \"Garry's Mod (x64)\"\n"
+                         "        string lightspeed_layer_type = \"replacement\"\n"
+                         "    }\n"
+                         "    metersPerUnit = 0.01\n"
+                         "    subLayers = [\n";
+    for (std::size_t index = 0; index < profileIds.size(); ++index) {
+        output += "        @./profiles/" + profileIds[index] + ".usda@";
+        if (index + 1 < profileIds.size()) output += ',';
+        output += '\n';
+    }
+    output += "    ]\n"
+              "    timeCodesPerSecond = 24\n"
+              "    upAxis = \"Z\"\n"
+              ")\n";
+    return output;
+}
+
+bool RootReferences(const std::string& rootContents,
+                    const std::filesystem::path& layerPath) {
+    return rootContents.find("./profiles/" + layerPath.filename().string()) !=
+        std::string::npos;
+}
+
+bool HasTextureInput(const std::string& layerContents, const std::string& input,
+                     const std::string& colorSpace) {
+    const auto inputPosition = layerContents.find("asset inputs:" + input + " = @");
+    if (inputPosition == std::string::npos) return false;
+    const auto inputEnd = layerContents.find("                )", inputPosition);
+    if (inputEnd == std::string::npos) return false;
+    const auto colorPosition = layerContents.find(
+        "colorSpace = \"" + colorSpace + "\"", inputPosition);
+    return colorPosition != std::string::npos && colorPosition < inputEnd;
+}
+
+bool IsVersionedHashLayer(const std::filesystem::path& path,
+                          std::string_view hash) {
+    const auto filename = path.filename().string();
+    const std::string prefix = "hash_" + std::string(hash) + "_";
+    constexpr std::string_view suffix = ".usda";
+    return filename.size() == prefix.size() + 16 + suffix.size() &&
+        filename.compare(0, prefix.size(), prefix) == 0 &&
+        filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::vector<std::filesystem::path> FindVersionedHashLayers(
+    const std::filesystem::path& profiles, std::string_view hash) {
+    std::vector<std::filesystem::path> found;
+    std::error_code ec;
+    if (!std::filesystem::is_directory(profiles, ec) || ec) return found;
+    for (std::filesystem::directory_iterator iterator(profiles, ec), end;
+         !ec && iterator != end; iterator.increment(ec)) {
+        if (iterator->is_regular_file(ec) && !ec &&
+            IsVersionedHashLayer(iterator->path(), hash)) {
+            found.push_back(iterator->path());
+        }
+    }
+    assert(!ec);
+    std::sort(found.begin(), found.end());
+    return found;
+}
+
+std::size_t CountRegularFiles(const std::filesystem::path& directory) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(directory, ec) || ec) return 0;
+    std::size_t count = 0;
+    for (std::filesystem::directory_iterator iterator(directory, ec), end;
+         !ec && iterator != end; iterator.increment(ec)) {
+        if (iterator->is_regular_file(ec) && !ec) ++count;
+    }
+    assert(!ec);
+    return count;
+}
+
+std::size_t CountRegularFilesRecursive(const std::filesystem::path& directory) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(directory, ec) || ec) return 0;
+    std::size_t count = 0;
+    for (std::filesystem::recursive_directory_iterator iterator(directory, ec), end;
+         !ec && iterator != end; iterator.increment(ec)) {
+        if (iterator->is_regular_file(ec) && !ec) ++count;
+    }
+    assert(!ec);
+    return count;
+}
+
+std::string HexHash(std::uint64_t value) {
+    std::ostringstream output;
+    output << std::uppercase << std::hex << std::setfill('0') <<
+        std::setw(16) << value;
+    return output.str();
+}
+
+} // namespace
+
+int main() {
+    std::string error;
+    std::string canonical;
+    assert(ValidateProfileId("material_0123", error));
+    assert(!ValidateProfileId("../escape", error));
+    assert(CanonicalizeHash("0xabc", canonical, error));
+    assert(canonical == "0000000000000ABC");
+    assert(!CanonicalizeHash("0x0", canonical, error));
+    assert(!CanonicalizeHash("xyz", canonical, error));
+    BridgeOperation operation = BridgeOperation::Preview;
+    assert(ParseBridgeOperation("", operation, error));
+    assert(operation == BridgeOperation::Commit);
+    assert(ParseBridgeOperation("PREVIEW", operation, error));
+    assert(operation == BridgeOperation::Preview);
+    assert(ParseBridgeOperation("restore", operation, error));
+    assert(operation == BridgeOperation::Restore);
+    assert(ParseBridgeOperation("clear", operation, error));
+    assert(operation == BridgeOperation::Clear);
+    assert(!ParseBridgeOperation("temporary", operation, error));
+
+    Config defaults;
+    assert(defaults.maxTextureBytes == 32ull * 1024ull * 1024ull);
+    assert(defaults.maxTextureDimension == 2048);
+    assert(defaults.maxActiveProfiles == 4096);
+    assert(defaults.maxActiveTextureFiles == 8192);
+    assert(defaults.maxActiveTextureBytes == 2ull * 1024ull * 1024ull * 1024ull);
+    assert(kMaxTextureOperations == 4);
+
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+        ("advmat_rtx_writer_test_" + std::to_string(nonce));
+    std::filesystem::create_directories(root / "garrysmod" / "data");
+    std::filesystem::create_directories(root / "rtx-remix" / "mods");
+    const auto nestedExecutable = root / "bin" / "win64" / "gmod.exe";
+    WriteText(nestedExecutable, "test executable placeholder");
+    const auto discoveredRoot = FindGameRootFromExecutable(nestedExecutable);
+    assert(discoveredRoot && *discoveredRoot == root.lexically_normal());
+    assert(!FindGameRootFromExecutable("bin/win64/gmod.exe"));
+
+    auto tooDeepDirectory = root;
+    for (std::size_t index = 0; index < kMaxGameRootAncestorDepth + 1; ++index) {
+        tooDeepDirectory /= "nested";
+    }
+    const auto tooDeepExecutable = tooDeepDirectory / "gmod.exe";
+    WriteText(tooDeepExecutable, "test executable placeholder");
+    assert(!FindGameRootFromExecutable(tooDeepExecutable));
+
+    const auto source = root / "garrysmod" / "data" / "source.dds";
+    WriteMinimalDds(source);
+
+    Config config;
+    config.gameRoot = root;
+    Bridge bridge(std::move(config));
+    const auto capabilities = bridge.GetCapabilities();
+    assert(capabilities.available);
+    assert(!capabilities.livePreview);
+    assert(capabilities.authoritativeReset);
+    assert(capabilities.synchronous);
+    assert(capabilities.maxTextureBytes == kDefaultMaxTextureBytes);
+    assert(capabilities.maxTextureDimension == kDefaultMaxTextureDimension);
+    assert(capabilities.maxTextureOperations == kMaxTextureOperations);
+    assert(capabilities.maxActiveProfiles == kDefaultMaxActiveProfiles);
+    assert(capabilities.maxActiveTextureFiles == kDefaultMaxActiveTextureFiles);
+    assert(capabilities.maxActiveTextureBytes == kDefaultMaxActiveTextureBytes);
+    ApplyRequest request;
+    request.profileId = "material_0123456789ABCDEF";
+    request.hashes = {"0x0123456789abcdef", "0123456789ABCDF0"};
+    request.material.albedo = Vec3{0.8f, 0.7f, 0.6f};
+    request.material.roughness = 0.25f;
+    request.material.metallic = 0.75f;
+    request.material.spriteSheetRows = 2;
+    request.material.spriteSheetColumns = 3;
+    request.material.spriteSheetFps = 4;
+    request.material.filterMode = 1;
+    request.material.wrapModeU = 1;
+    request.material.wrapModeV = 2;
+    request.material.blendType = 8;
+    request.material.alphaTestType = 7;
+    request.material.alphaReferenceValue = 0.5f;
+    request.material.textures.push_back({TextureRole::Albedo, source, {}});
+
+    const auto expectedMod = root / "rtx-remix" / "mods" / "!advanced_material_editor";
+
+    // Destination containment is physical, not merely lexical. Exercise both
+    // a junction/symlink present during construction and components planted
+    // after provider discovery. Windows may require Developer Mode for test
+    // symlink creation, so each attack case is conditional on host support.
+    const auto linkedRoot = root / "linked_game";
+    const auto linkedExternal = root / "linked_external";
+    std::filesystem::create_directories(linkedRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(linkedRoot / "rtx-remix");
+    WriteText(linkedExternal / "keep.txt", "outside constructor sentinel");
+    std::error_code linkError;
+    std::filesystem::create_directory_symlink(
+        linkedExternal, linkedRoot / "rtx-remix" / "mods", linkError);
+    if (!linkError) {
+        Config linkedConfig;
+        linkedConfig.gameRoot = linkedRoot;
+        Bridge linkedBridge(std::move(linkedConfig));
+        assert(!linkedBridge.GetCapabilities().available);
+        assert(ReadText(linkedExternal / "keep.txt") == "outside constructor sentinel");
+    }
+
+    const auto redirectedRoot = root / "redirected_game";
+    const auto redirectedExternal = root / "redirected_external";
+    const auto redirectedSource = redirectedRoot / "garrysmod" / "data" / "source.dds";
+    std::filesystem::create_directories(redirectedRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(redirectedRoot / "rtx-remix" / "mods");
+    WriteMinimalDds(redirectedSource);
+    WriteText(redirectedExternal / "keep.txt", "outside runtime sentinel");
+    Config redirectedConfig;
+    redirectedConfig.gameRoot = redirectedRoot;
+    Bridge redirectedBridge(std::move(redirectedConfig));
+    assert(redirectedBridge.GetCapabilities().available);
+    ApplyRequest redirectedRequest = request;
+    redirectedRequest.material.textures.front().source = redirectedSource;
+    const auto redirectedMods = redirectedRoot / "rtx-remix" / "mods";
+    const auto redirectedMod = redirectedMods / "!advanced_material_editor";
+
+    linkError.clear();
+    std::filesystem::remove(redirectedMods, linkError);
+    assert(!linkError);
+    std::filesystem::create_directory_symlink(redirectedExternal, redirectedMods, linkError);
+    if (!linkError) {
+        const auto redirectedAncestor = redirectedBridge.ApplyLegacyMaterial(redirectedRequest);
+        assert(!redirectedAncestor.ok);
+        assert(ReadText(redirectedExternal / "keep.txt") == "outside runtime sentinel");
+        assert(!std::filesystem::exists(redirectedExternal / "!advanced_material_editor"));
+        std::filesystem::remove(redirectedMods, linkError);
+        assert(!linkError);
+    } else {
+        linkError.clear();
+    }
+    std::filesystem::create_directories(redirectedMod);
+
+    linkError.clear();
+    std::filesystem::create_directory_symlink(
+        redirectedExternal, redirectedMod / "textures", linkError);
+    if (!linkError) {
+        const auto redirectedTexture = redirectedBridge.ApplyLegacyMaterial(redirectedRequest);
+        assert(!redirectedTexture.ok);
+        assert(ReadText(redirectedExternal / "keep.txt") == "outside runtime sentinel");
+        std::filesystem::remove(redirectedMod / "textures", linkError);
+        assert(!linkError);
+    } else {
+        linkError.clear();
+    }
+
+    const auto redirectedTextureDirectory = redirectedMod / "textures";
+    std::filesystem::create_directories(redirectedTextureDirectory);
+    const auto redirectedNestedTexture = redirectedTextureDirectory / "nested_reparse";
+    linkError.clear();
+    std::filesystem::create_directory_symlink(
+        redirectedExternal, redirectedNestedTexture, linkError);
+    if (!linkError) {
+        const auto redirectedNested =
+            redirectedBridge.ApplyLegacyMaterial(redirectedRequest);
+        assert(!redirectedNested.ok);
+        assert(ReadText(redirectedExternal / "keep.txt") == "outside runtime sentinel");
+        std::filesystem::remove(redirectedNestedTexture, linkError);
+        assert(!linkError);
+    } else {
+        linkError.clear();
+    }
+    std::filesystem::remove(redirectedTextureDirectory, linkError);
+    assert(!linkError);
+
+    linkError.clear();
+    std::filesystem::create_directory_symlink(
+        redirectedExternal, redirectedMod / "profiles", linkError);
+    if (!linkError) {
+        auto redirectedProfileRequest = redirectedRequest;
+        redirectedProfileRequest.material.textures.clear();
+        const auto redirectedProfile =
+            redirectedBridge.ApplyLegacyMaterial(redirectedProfileRequest);
+        assert(!redirectedProfile.ok);
+        assert(ReadText(redirectedExternal / "keep.txt") == "outside runtime sentinel");
+        std::filesystem::remove(redirectedMod / "profiles", linkError);
+        assert(!linkError);
+    } else {
+        linkError.clear();
+    }
+
+    const auto redirectedExternalRoot = redirectedExternal / "external_mod.usda";
+    WriteText(redirectedExternalRoot, "outside root sentinel");
+    linkError.clear();
+    std::filesystem::create_symlink(
+        redirectedExternalRoot, redirectedMod / "mod.usda", linkError);
+    if (!linkError) {
+        const auto redirectedRootLayer =
+            redirectedBridge.ApplyLegacyMaterial(redirectedRequest);
+        assert(!redirectedRootLayer.ok);
+        assert(ReadText(redirectedExternalRoot) == "outside root sentinel");
+        std::filesystem::remove(redirectedMod / "mod.usda", linkError);
+        assert(!linkError);
+    }
+
+    request.operation = BridgeOperation::Preview;
+    const auto preview = bridge.ApplyLegacyMaterial(request);
+    assert(!preview.ok);
+    assert(preview.code == "preview_unsupported");
+    // A preview request must not create even the addon's dedicated mod folder.
+    assert(!std::filesystem::exists(expectedMod));
+    request.operation = BridgeOperation::Commit;
+
+    auto invalidSpriteSheet = request;
+    invalidSpriteSheet.material.spriteSheetRows = 0;
+    const auto invalidRows = bridge.ApplyLegacyMaterial(invalidSpriteSheet);
+    assert(!invalidRows.ok && invalidRows.code == "invalid_material");
+    invalidSpriteSheet = request;
+    invalidSpriteSheet.material.spriteSheetColumns = 0;
+    const auto invalidColumns = bridge.ApplyLegacyMaterial(invalidSpriteSheet);
+    assert(!invalidColumns.ok && invalidColumns.code == "invalid_material");
+    assert(!std::filesystem::exists(expectedMod));
+
+    const auto applied = bridge.ApplyLegacyMaterial(request);
+    if (!applied.ok) {
+        std::cerr << applied.code << ": " << applied.message << '\n';
+        return 1;
+    }
+    assert(bridge.ModDirectory() == expectedMod);
+    assert(std::filesystem::is_regular_file(applied.layerPath));
+    assert(applied.layerPaths.size() == 2);
+    assert(IsVersionedHashLayer(applied.layerPaths[0], "0123456789ABCDEF"));
+    assert(IsVersionedHashLayer(applied.layerPaths[1], "0123456789ABCDF0"));
+    assert(applied.importedTextures.size() == 1);
+    assert(std::filesystem::is_regular_file(applied.importedTextures.front()));
+
+    const auto firstProfileText = ReadText(applied.layerPaths[0]);
+    const auto secondProfileText = ReadText(applied.layerPaths[1]);
+    assert(firstProfileText.find("mat_0123456789ABCDEF") != std::string::npos);
+    assert(firstProfileText.find("mat_0123456789ABCDF0") == std::string::npos);
+    assert(secondProfileText.find("mat_0123456789ABCDF0") != std::string::npos);
+    assert(secondProfileText.find("mat_0123456789ABCDEF") == std::string::npos);
+    assert(firstProfileText.find("AperturePBR_Opacity.mdl") != std::string::npos);
+    assert(firstProfileText.find("subIdentifier = \"AperturePBR_Opacity\"") !=
+        std::string::npos);
+    assert(firstProfileText.find("reflection_roughness_constant = 0.25") != std::string::npos);
+    assert(firstProfileText.find("metallic_constant = 0.75") != std::string::npos);
+    assert(firstProfileText.find("diffuse_texture") != std::string::npos);
+    assert(firstProfileText.find("int inputs:sprite_sheet_rows = 2") != std::string::npos);
+    assert(firstProfileText.find("int inputs:sprite_sheet_cols = 3") != std::string::npos);
+    assert(firstProfileText.find("int inputs:sprite_sheet_fps = 4") != std::string::npos);
+    assert(firstProfileText.find("int inputs:filter_mode = 1") != std::string::npos);
+    assert(firstProfileText.find("int inputs:wrap_mode_u = 1") != std::string::npos);
+    assert(firstProfileText.find("int inputs:wrap_mode_v = 2") != std::string::npos);
+    assert(firstProfileText.find("bool inputs:blend_enabled = 1") != std::string::npos);
+    assert(firstProfileText.find("int inputs:blend_type = 8") != std::string::npos);
+    assert(firstProfileText.find("int inputs:alpha_test_type = 7") != std::string::npos);
+    assert(firstProfileText.find("float inputs:alpha_test_reference_value = 0.5") !=
+        std::string::npos);
+    assert(firstProfileText.find("uchar inputs:") == std::string::npos);
+
+    const auto modText = ReadText(expectedMod / "mod.usda");
+    assert(RootReferences(modText, applied.layerPaths[0]));
+    assert(RootReferences(modText, applied.layerPaths[1]));
+    assert(modText.find("./profiles/material_0123456789ABCDEF.usda") == std::string::npos);
+    assert(modText.find("~gmod_topbr") == std::string::npos);
+
+    // Reapplying an unchanged profile must reuse the content-addressed DDS and
+    // avoid touching either USDA layer. This is important because calls are
+    // synchronous on the game's client thread.
+    const auto oldTime = std::filesystem::file_time_type::clock::now() -
+        std::chrono::hours(24);
+    std::filesystem::last_write_time(applied.layerPath, oldTime);
+    std::filesystem::last_write_time(applied.layerPaths[1], oldTime);
+    std::filesystem::last_write_time(expectedMod / "mod.usda", oldTime);
+    std::filesystem::last_write_time(applied.importedTextures.front(), oldTime);
+    const auto oldProfileTime = std::filesystem::last_write_time(applied.layerPath);
+    const auto oldSecondProfileTime = std::filesystem::last_write_time(applied.layerPaths[1]);
+    const auto oldModTime = std::filesystem::last_write_time(expectedMod / "mod.usda");
+    const auto oldTextureTime = std::filesystem::last_write_time(applied.importedTextures.front());
+    const auto reapplied = bridge.ApplyLegacyMaterial(request);
+    assert(reapplied.ok);
+    assert(reapplied.layerPaths == applied.layerPaths);
+    assert(std::filesystem::last_write_time(applied.layerPath) == oldProfileTime);
+    assert(std::filesystem::last_write_time(applied.layerPaths[1]) == oldSecondProfileTime);
+    assert(std::filesystem::last_write_time(expectedMod / "mod.usda") == oldModTime);
+    assert(std::filesystem::last_write_time(applied.importedTextures.front()) == oldTextureTime);
+
+    const auto previewAfterCommit = [&]() {
+        auto previewRequest = request;
+        previewRequest.operation = BridgeOperation::Preview;
+        return bridge.ApplyLegacyMaterial(previewRequest);
+    }();
+    assert(!previewAfterCommit.ok && previewAfterCommit.code == "preview_unsupported");
+    assert(std::filesystem::last_write_time(applied.layerPath) == oldProfileTime);
+    assert(std::filesystem::last_write_time(applied.layerPaths[1]) == oldSecondProfileTime);
+    assert(std::filesystem::last_write_time(expectedMod / "mod.usda") == oldModTime);
+    assert(std::filesystem::last_write_time(applied.importedTextures.front()) == oldTextureTime);
+
+    // A content-addressed filename alone is not enough to trust a pre-existing
+    // cache entry. Reapplying must replace a truncated destination rather than
+    // publishing a profile that points Remix at malformed DDS data.
+    const auto sourceTextureSize = std::filesystem::file_size(source);
+    const auto rootBeforeCacheRepair = ReadText(expectedMod / "mod.usda");
+    {
+        std::fstream cache(applied.importedTextures.front(),
+                           std::ios::binary | std::ios::in | std::ios::out);
+        assert(cache);
+        cache.seekp(128);
+        cache.put(static_cast<char>(0xee));
+    }
+    assert(std::filesystem::file_size(applied.importedTextures.front()) == sourceTextureSize);
+    assert(ReadText(applied.importedTextures.front()) != ReadText(source));
+    const auto repairedCache = bridge.ApplyLegacyMaterial(request);
+    assert(repairedCache.ok);
+    assert(std::filesystem::file_size(applied.importedTextures.front()) == sourceTextureSize);
+    assert(ReadText(applied.importedTextures.front()) == ReadText(source));
+    assert(ReadText(expectedMod / "mod.usda") == rootBeforeCacheRepair);
+    std::filesystem::resize_file(applied.importedTextures.front(), 128);
+    const auto repairedTruncatedCache = bridge.ApplyLegacyMaterial(request);
+    assert(repairedTruncatedCache.ok);
+    assert(ReadText(applied.importedTextures.front()) == ReadText(source));
+    assert(ReadText(expectedMod / "mod.usda") == rootBeforeCacheRepair);
+
+    // A multi-hash update is staged into new immutable revisions. Failure after
+    // the first staged layer must leave both previously active revisions and
+    // the root activation ledger byte-for-byte intact.
+    const auto committedRootText = ReadText(expectedMod / "mod.usda");
+    int stagedLayerCount = 0;
+    Config midStageFailureConfig;
+    midStageFailureConfig.gameRoot = root;
+    midStageFailureConfig.failureInjector = [&stagedLayerCount](std::string_view point) {
+        if (point != "apply_after_stage_layer") return false;
+        ++stagedLayerCount;
+        return stagedLayerCount == 1;
+    };
+    Bridge midStageFailureBridge(std::move(midStageFailureConfig));
+    ApplyRequest changedRequest = request;
+    changedRequest.material.roughness = 0.9f;
+    const auto midStageFailure = midStageFailureBridge.ApplyLegacyMaterial(changedRequest);
+    assert(!midStageFailure.ok && midStageFailure.code == "injected_failure");
+    assert(stagedLayerCount == 1);
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+    assert(ReadText(applied.layerPaths[0]) == firstProfileText);
+    assert(ReadText(applied.layerPaths[1]) == secondProfileText);
+    assert(RootReferences(ReadText(expectedMod / "mod.usda"), applied.layerPaths[0]));
+    assert(RootReferences(ReadText(expectedMod / "mod.usda"), applied.layerPaths[1]));
+    assert(FindVersionedHashLayers(expectedMod / "profiles",
+        "0123456789ABCDEF").size() == 1);
+    assert(FindVersionedHashLayers(expectedMod / "profiles",
+        "0123456789ABCDF0").size() == 1);
+
+    // Failure after every new revision is durable but before publication has
+    // the same all-old result; active-ledger cleanup removes the inert staged
+    // files before the failure is returned.
+    bool reachedPrePublish = false;
+    Config prePublishFailureConfig;
+    prePublishFailureConfig.gameRoot = root;
+    prePublishFailureConfig.failureInjector = [&reachedPrePublish](std::string_view point) {
+        if (point != "apply_before_root_publish") return false;
+        reachedPrePublish = true;
+        return true;
+    };
+    Bridge prePublishFailureBridge(std::move(prePublishFailureConfig));
+    changedRequest.material.roughness = 0.8f;
+    const auto prePublishFailure =
+        prePublishFailureBridge.ApplyLegacyMaterial(changedRequest);
+    assert(!prePublishFailure.ok && prePublishFailure.code == "injected_failure");
+    assert(reachedPrePublish);
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+    assert(ReadText(applied.layerPaths[0]) == firstProfileText);
+    assert(ReadText(applied.layerPaths[1]) == secondProfileText);
+    assert(FindVersionedHashLayers(expectedMod / "profiles",
+        "0123456789ABCDEF").size() == 1);
+    assert(FindVersionedHashLayers(expectedMod / "profiles",
+        "0123456789ABCDF0").size() == 1);
+
+    // Failure after creating a new map and profile revision removes both
+    // transaction-owned orphans while the old root remains active.
+    ApplyRequest failedGeneration = request;
+    failedGeneration.profileId = "failed_transaction";
+    failedGeneration.hashes = {"00000000FA11ED01"};
+    failedGeneration.material.textures.clear();
+    failedGeneration.material.textures.push_back(
+        {TextureRole::Anisotropy, source, {}});
+    const auto failedGenerationResult =
+        prePublishFailureBridge.ApplyLegacyMaterial(failedGeneration);
+    assert(!failedGenerationResult.ok &&
+        failedGenerationResult.code == "injected_failure");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+    assert(!std::filesystem::exists(expectedMod / "textures" / "failed_transaction"));
+    assert(FindVersionedHashLayers(expectedMod / "profiles",
+        "00000000FA11ED01").empty());
+
+    ApplyRequest tooManyOperations = request;
+    tooManyOperations.profileId = "operation_limit";
+    tooManyOperations.material.textures.front().operations.assign(
+        kMaxTextureOperations + 1, TextureOperation{});
+    const auto operationLimit = bridge.ApplyLegacyMaterial(tooManyOperations);
+    assert(!operationLimit.ok && operationLimit.code == "invalid_material");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    ApplyRequest invalidBlend = request;
+    invalidBlend.material.blendType = 9;
+    const auto blendLimit = bridge.ApplyLegacyMaterial(invalidBlend);
+    assert(!blendLimit.ok && blendLimit.code == "invalid_material");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    ApplyRequest invalidFilter = request;
+    invalidFilter.material.filterMode = 2;
+    const auto filterLimit = bridge.ApplyLegacyMaterial(invalidFilter);
+    assert(!filterLimit.ok && filterLimit.code == "invalid_material");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    ApplyRequest invalidWrap = request;
+    invalidWrap.material.wrapModeU = 4;
+    const auto wrapLimit = bridge.ApplyLegacyMaterial(invalidWrap);
+    assert(!wrapLimit.ok && wrapLimit.code == "invalid_material");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    for (const int invalidAlphaTest : {-1, 8}) {
+        ApplyRequest invalidAlpha = request;
+        invalidAlpha.material.alphaTestType = invalidAlphaTest;
+        const auto alphaLimit = bridge.ApplyLegacyMaterial(invalidAlpha);
+        assert(!alphaLimit.ok && alphaLimit.code == "invalid_material");
+        assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+    }
+
+    const auto oversizedDimensionSource = root / "garrysmod" / "data" / "too_wide.dds";
+    WriteMinimalDds(oversizedDimensionSource, kDefaultMaxTextureDimension + 1, 1);
+    ApplyRequest oversizedDimension = request;
+    oversizedDimension.profileId = "dimension_limit";
+    oversizedDimension.material.textures.front().source = oversizedDimensionSource;
+    const auto dimensionLimit = bridge.ApplyLegacyMaterial(oversizedDimension);
+    assert(!dimensionLimit.ok && dimensionLimit.code == "invalid_dds");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    const auto truncatedPayloadSource =
+        root / "garrysmod" / "data" / "truncated_payload.dds";
+    WriteMinimalDds(truncatedPayloadSource, 2048, 2048, 1, 4);
+    ApplyRequest truncatedPayload = request;
+    truncatedPayload.profileId = "truncated_payload";
+    truncatedPayload.material.textures.front().source = truncatedPayloadSource;
+    const auto truncatedPayloadResult = bridge.ApplyLegacyMaterial(truncatedPayload);
+    assert(!truncatedPayloadResult.ok && truncatedPayloadResult.code == "invalid_dds");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    const auto truncatedMipSource =
+        root / "garrysmod" / "data" / "truncated_mips.dds";
+    WriteMinimalDds(truncatedMipSource, 4, 4, 3);
+    ApplyRequest truncatedMips = request;
+    truncatedMips.profileId = "truncated_mips";
+    truncatedMips.material.textures.front().source = truncatedMipSource;
+    const auto truncatedMipResult = bridge.ApplyLegacyMaterial(truncatedMips);
+    assert(!truncatedMipResult.ok && truncatedMipResult.code == "invalid_dds");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    const auto malformedDx10Source =
+        root / "garrysmod" / "data" / "missing_dx10_header.dds";
+    WriteMalformedDx10Dds(malformedDx10Source);
+    ApplyRequest malformedDx10 = request;
+    malformedDx10.profileId = "missing_dx10_header";
+    malformedDx10.material.textures.front().source = malformedDx10Source;
+    const auto malformedDx10Result = bridge.ApplyLegacyMaterial(malformedDx10);
+    assert(!malformedDx10Result.ok && malformedDx10Result.code == "invalid_dds");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    ApplyRequest partialTextureFailure = request;
+    partialTextureFailure.profileId = "partial_texture_failure";
+    partialTextureFailure.material.textures.clear();
+    partialTextureFailure.material.textures.push_back(
+        {TextureRole::Anisotropy, source, {}});
+    partialTextureFailure.material.textures.push_back(
+        {TextureRole::Normal, oversizedDimensionSource, {}});
+    const auto partialTextureResult = bridge.ApplyLegacyMaterial(partialTextureFailure);
+    assert(!partialTextureResult.ok && partialTextureResult.code == "invalid_dds");
+    assert(!std::filesystem::exists(
+        expectedMod / "textures" / "partial_texture_failure"));
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    const auto protectedSource =
+        root / "rtx-remix" / "mods" / "~gmod_topbr" / "protected.dds";
+    WriteMinimalDds(protectedSource);
+    ApplyRequest protectedInput = request;
+    protectedInput.profileId = "protected_input";
+    protectedInput.material.textures.front().source = protectedSource;
+    const auto protectedResult = bridge.ApplyLegacyMaterial(protectedInput);
+    assert(!protectedResult.ok && protectedResult.code == "protected_texture_path");
+    assert(ReadText(expectedMod / "mod.usda") == committedRootText);
+
+    assert(!bridge.ClearLegacyMaterial({request.profileId, {}}).ok);
+    const auto cleared = bridge.ClearLegacyMaterial(
+        {request.profileId, {"0x0123456789ABCDEF"}});
+    assert(cleared.ok);
+    // The just-disabled revision remains as the single previous generation.
+    // Only the atomically published root decides which revisions are active.
+    assert(std::filesystem::is_regular_file(applied.layerPaths[0]));
+    assert(std::filesystem::is_regular_file(applied.layerPaths[1]));
+    assert(std::filesystem::is_regular_file(cleared.layerPath));
+    const auto clearedModText = ReadText(expectedMod / "mod.usda");
+    assert(!RootReferences(clearedModText, applied.layerPaths[0]));
+    assert(RootReferences(clearedModText, applied.layerPaths[1]));
+    // An exact-hash clear is deliberately idempotent and cannot touch the
+    // surviving hash layer for the same Source material.
+    std::filesystem::last_write_time(cleared.layerPath, oldTime);
+    std::filesystem::last_write_time(applied.layerPaths[1], oldTime);
+    std::filesystem::last_write_time(expectedMod / "mod.usda", oldTime);
+    const auto survivingTime = std::filesystem::last_write_time(applied.layerPaths[1]);
+    const auto oldClearedModTime = std::filesystem::last_write_time(expectedMod / "mod.usda");
+    assert(bridge.ClearLegacyMaterial(
+        {request.profileId, {"0x0123456789ABCDEF"}}).ok);
+    assert(!std::filesystem::exists(cleared.layerPath));
+    assert(std::filesystem::last_write_time(applied.layerPaths[1]) == survivingTime);
+    assert(std::filesystem::last_write_time(expectedMod / "mod.usda") == oldClearedModTime);
+
+    assert(bridge.ClearLegacyMaterial(
+        {request.profileId, {"0x0123456789ABCDF0"}}).ok);
+    assert(std::filesystem::is_regular_file(applied.layerPaths[1]));
+    const auto fullyClearedModText = ReadText(expectedMod / "mod.usda");
+    assert(fullyClearedModText.find("hash_0123456789ABCDEF") == std::string::npos);
+    assert(fullyClearedModText.find("hash_0123456789ABCDF0") == std::string::npos);
+
+    // Migrate an aggregate material_<id> layer from the pre-hash layout, then
+    // clear only one hash. The other raw shader block must survive in its own
+    // layer, and retrying the retired hash must remain harmless.
+    const std::string legacyHash1 = "000000000000AAA1";
+    const std::string legacyHash2 = "000000000000AAA2";
+    const std::string legacyProfile = "material_legacy_migration";
+    const auto legacyPath = expectedMod / "profiles" / (legacyProfile + ".usda");
+    const auto legacyContents = LegacyLayer({legacyHash1, legacyHash2});
+    WriteText(legacyPath, legacyContents);
+    WriteText(expectedMod / "mod.usda", ModLayer({legacyProfile}));
+    const auto migratedClear = bridge.ClearLegacyMaterial(
+        {legacyProfile, {legacyHash1}});
+    assert(migratedClear.ok);
+    const auto migratedHash1Layers = FindVersionedHashLayers(
+        expectedMod / "profiles", legacyHash1);
+    const auto migratedHash2Layers = FindVersionedHashLayers(
+        expectedMod / "profiles", legacyHash2);
+    assert(migratedHash1Layers.size() == 1);
+    assert(migratedHash2Layers.size() == 1);
+    const auto& migratedHash1 = migratedHash1Layers.front();
+    const auto& migratedHash2 = migratedHash2Layers.front();
+    assert(std::filesystem::is_regular_file(migratedHash1));
+    assert(std::filesystem::is_regular_file(migratedHash2));
+    assert(std::filesystem::is_regular_file(legacyPath));
+    assert(ReadText(legacyPath) == legacyContents);
+    const auto migratedModText = ReadText(expectedMod / "mod.usda");
+    assert(!RootReferences(migratedModText, legacyPath));
+    assert(!RootReferences(migratedModText, migratedHash1));
+    assert(RootReferences(migratedModText, migratedHash2));
+    const auto migratedHash2Text = ReadText(migratedHash2);
+    assert(migratedHash2Text.find("mat_" + legacyHash2) != std::string::npos);
+    const auto migratedRootBeforeRetry = ReadText(expectedMod / "mod.usda");
+    assert(bridge.ClearLegacyMaterial({legacyProfile, {legacyHash1}}).ok);
+    assert(!std::filesystem::exists(legacyPath));
+    assert(!std::filesystem::exists(migratedHash1));
+    assert(std::filesystem::is_regular_file(migratedHash2));
+    assert(ReadText(expectedMod / "mod.usda") == migratedRootBeforeRetry);
+    assert(bridge.ClearLegacyMaterial({legacyProfile, {legacyHash2}}).ok);
+    assert(std::filesystem::is_regular_file(migratedHash2));
+    assert(ReadText(expectedMod / "mod.usda").find("hash_") == std::string::npos);
+
+    // Every edit begins by pruning files not referenced by the current root,
+    // then leaves at most the just-superseded generation for watcher safety.
+    // Repeated successful edits therefore stay bounded within one session.
+    const std::string churnHash = "00000000C0FFEE01";
+    ApplyRequest churnRequest = request;
+    churnRequest.profileId = "bounded_churn";
+    churnRequest.hashes = {churnHash};
+    for (std::uint32_t revision = 1; revision <= 12; ++revision) {
+        const auto churnSource = root / "garrysmod" / "data" /
+            ("churn_" + std::to_string(revision) + ".dds");
+        WriteMinimalDds(churnSource, revision, 1);
+        churnRequest.material.roughness = revision / 16.0f;
+        churnRequest.material.textures.clear();
+        churnRequest.material.textures.push_back(
+            {TextureRole::Albedo, churnSource, {}});
+        const auto churnApply = bridge.ApplyLegacyMaterial(churnRequest);
+        assert(churnApply.ok && churnApply.layerPaths.size() == 1);
+    }
+    const auto churnLayers = FindVersionedHashLayers(
+        expectedMod / "profiles", churnHash);
+    assert(churnLayers.size() == 2);
+    assert(CountRegularFiles(expectedMod / "textures" / "bounded_churn") == 2);
+    assert(bridge.ClearLegacyMaterial({"bounded_churn", {churnHash}}).ok);
+
+    // Populate a larger active generation. ClearAllOwned must deactivate the
+    // entire set with one root publication, then retire the profile and texture
+    // generations with fixed directory renames independent of layer count.
+    ApplyRequest scaleRequest = request;
+    scaleRequest.profileId = "material_authoritative_reset_scale";
+    scaleRequest.hashes.clear();
+    for (std::uint64_t index = 0; index < 64; ++index) {
+        scaleRequest.hashes.push_back(HexHash(0x1000u + index));
+    }
+    const auto resetApply = bridge.ApplyLegacyMaterial(scaleRequest);
+    assert(resetApply.ok && resetApply.layerPaths.size() == 64);
+    const std::string resetLegacyProfile = "material_authoritative_reset";
+    const auto resetLegacyPath = expectedMod / "profiles" /
+        (resetLegacyProfile + ".usda");
+    WriteText(resetLegacyPath, LegacyLayer({legacyHash1}));
+    std::vector<std::string> resetActiveIds;
+    resetActiveIds.reserve(resetApply.layerPaths.size() + 1);
+    for (const auto& path : resetApply.layerPaths) {
+        resetActiveIds.push_back(path.stem().string());
+    }
+    resetActiveIds.push_back(resetLegacyProfile);
+    WriteText(expectedMod / "mod.usda", ModLayer(resetActiveIds));
+    const auto retainedTexture = resetApply.importedTextures.front();
+    assert(std::filesystem::is_regular_file(retainedTexture));
+
+    // A failure before the empty-root commit cannot change activation.
+    const auto activeRootBeforeReset = ReadText(expectedMod / "mod.usda");
+    Config resetBeforeConfig;
+    resetBeforeConfig.gameRoot = root;
+    resetBeforeConfig.failureInjector = [](std::string_view point) {
+        return point == "reset_before_root_publish";
+    };
+    Bridge resetBeforeBridge(std::move(resetBeforeConfig));
+    const auto resetBeforeFailure = resetBeforeBridge.ClearAllOwned();
+    assert(!resetBeforeFailure.ok && resetBeforeFailure.code == "injected_failure");
+    assert(ReadText(expectedMod / "mod.usda") == activeRootBeforeReset);
+    assert(std::filesystem::is_directory(expectedMod / "profiles"));
+
+    // A simulated crash immediately after the empty-root commit leaves every
+    // old layer on disk but none active. A retry may then retire the directory
+    // without risking reactivation.
+    Config resetAfterConfig;
+    resetAfterConfig.gameRoot = root;
+    resetAfterConfig.failureInjector = [](std::string_view point) {
+        return point == "reset_after_root_publish";
+    };
+    Bridge resetAfterBridge(std::move(resetAfterConfig));
+    const auto resetAfterFailure = resetAfterBridge.ClearAllOwned();
+    assert(!resetAfterFailure.ok &&
+        resetAfterFailure.code == "injected_failure_after_commit");
+    const auto emptyRootText = ReadText(expectedMod / "mod.usda");
+    assert(emptyRootText == ModLayer({}));
+    assert(std::filesystem::is_directory(expectedMod / "profiles"));
+    for (const auto& path : resetApply.layerPaths) {
+        assert(std::filesystem::is_regular_file(path));
+        assert(!RootReferences(emptyRootText, path));
+    }
+
+    // A failure between the two retirement renames is already past the empty
+    // root commit. Profiles may be quarantined while textures remain in their
+    // active cache path; retry must still rotate textures even though profiles/
+    // no longer exists.
+    Config resetBetweenConfig;
+    resetBetweenConfig.gameRoot = root;
+    resetBetweenConfig.failureInjector = [](std::string_view point) {
+        return point == "reset_after_profile_retire";
+    };
+    Bridge resetBetweenBridge(std::move(resetBetweenConfig));
+    const auto resetBetweenFailure = resetBetweenBridge.ClearAllOwned();
+    assert(!resetBetweenFailure.ok &&
+        resetBetweenFailure.code == "injected_failure_after_commit");
+    const auto retiredProfiles = expectedMod / "profiles.retired";
+    const auto retiredTextures = expectedMod / "textures.retired";
+    assert(std::filesystem::is_directory(retiredProfiles));
+    assert(!std::filesystem::exists(expectedMod / "profiles"));
+    assert(std::filesystem::is_directory(expectedMod / "textures"));
+    assert(!std::filesystem::exists(retiredTextures));
+    for (const auto& path : resetApply.layerPaths) {
+        assert(std::filesystem::is_regular_file(retiredProfiles / path.filename()));
+    }
+    assert(std::filesystem::is_regular_file(retiredProfiles / resetLegacyPath.filename()));
+    assert(std::filesystem::is_regular_file(retainedTexture));
+
+    const auto reset = bridge.ClearAllOwned();
+    assert(reset.ok && reset.layerPaths.empty());
+    const auto retainedTextureRelative = retainedTexture.lexically_relative(
+        expectedMod / "textures");
+    assert(!retainedTextureRelative.empty());
+    assert(!std::filesystem::exists(expectedMod / "textures"));
+    assert(std::filesystem::is_regular_file(
+        retiredTextures / retainedTextureRelative));
+    const auto resetModText = ReadText(expectedMod / "mod.usda");
+    assert(resetModText == ModLayer({}));
+
+    // Authoritative reset is idempotent and avoids needless watcher reloads.
+    std::filesystem::last_write_time(expectedMod / "mod.usda", oldTime);
+    const auto resetModTime = std::filesystem::last_write_time(expectedMod / "mod.usda");
+    const auto repeatedReset = bridge.ClearAllOwned();
+    assert(repeatedReset.ok && repeatedReset.layerPaths.empty());
+    assert(std::filesystem::last_write_time(expectedMod / "mod.usda") == resetModTime);
+    assert(std::filesystem::is_directory(retiredProfiles));
+    assert(std::filesystem::is_directory(retiredTextures));
+    assert(std::filesystem::is_regular_file(
+        retiredTextures / retainedTextureRelative));
+
+    // A later generation creates a fresh profiles/ directory. The retired
+    // generation remains outside the sole root ledger and cannot reactivate.
+    ApplyRequest postResetRequest = request;
+    postResetRequest.hashes = {"00000000FEEDFACE"};
+    const auto postResetApply = bridge.ApplyLegacyMaterial(postResetRequest);
+    assert(postResetApply.ok && postResetApply.layerPaths.size() == 1);
+    assert(postResetApply.importedTextures.size() == 1);
+    const auto postResetTexture = postResetApply.importedTextures.front();
+    assert(std::filesystem::is_regular_file(postResetTexture));
+    const auto postResetRoot = ReadText(expectedMod / "mod.usda");
+    assert(RootReferences(postResetRoot, postResetApply.layerPaths.front()));
+    assert(postResetRoot.find(retiredProfiles.filename().string()) == std::string::npos);
+    assert(std::filesystem::is_directory(retiredProfiles));
+
+    // A second populated reset replaces both fixed quarantines instead of
+    // creating per-session directories. A sentinel in the older texture cache
+    // proves that replacement happened rather than another generation being
+    // accumulated beside it.
+    WriteText(retiredTextures / "old_generation.marker", "old texture generation");
+    const auto rotatedReset = bridge.ClearAllOwned();
+    assert(rotatedReset.ok && rotatedReset.layerPaths.size() == 1);
+    assert(rotatedReset.layerPaths.front() == retiredProfiles);
+    assert(std::filesystem::is_regular_file(
+        retiredProfiles / postResetApply.layerPaths.front().filename()));
+    assert(!std::filesystem::exists(
+        retiredProfiles / resetApply.layerPaths.front().filename()));
+    assert(!std::filesystem::exists(retiredTextures / "old_generation.marker"));
+    const auto postResetTextureRelative = postResetTexture.lexically_relative(
+        expectedMod / "textures");
+    assert(!postResetTextureRelative.empty());
+    assert(!std::filesystem::exists(expectedMod / "textures"));
+    assert(std::filesystem::is_regular_file(
+        retiredTextures / postResetTextureRelative));
+    std::size_t profileRetirementDirectories = 0;
+    std::size_t textureRetirementDirectories = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(expectedMod)) {
+        const auto name = entry.path().filename().string();
+        if (name == "profiles.retired" || name.rfind("profiles.tmp.", 0) == 0) {
+            ++profileRetirementDirectories;
+        }
+        if (name == "textures.retired" || name.rfind("textures.tmp.", 0) == 0) {
+            ++textureRetirementDirectories;
+        }
+    }
+    assert(profileRetirementDirectories == 1);
+    assert(textureRetirementDirectories == 1);
+
+    // Refuse planted quarantine symlinks/junctions rather than allowing
+    // recursive cleanup to cross the fixed mod boundary. Cover both a nested
+    // entry and the exact quarantine root. Symlink creation may require
+    // Developer Mode on Windows, so each assertion is conditional on support.
+    const auto reparseApply = bridge.ApplyLegacyMaterial(postResetRequest);
+    assert(reparseApply.ok && reparseApply.importedTextures.size() == 1);
+    const auto externalTextureDirectory = root / "external_texture_sentinel";
+    const auto externalTextureSentinel = externalTextureDirectory / "keep.txt";
+    WriteText(externalTextureSentinel, "outside texture sentinel");
+    std::error_code reparseError;
+    const auto nestedReparse = retiredTextures / "planted_reparse";
+    std::filesystem::create_directory_symlink(
+        externalTextureDirectory, nestedReparse, reparseError);
+    if (!reparseError) {
+        const auto unsafeNestedRetirement = bridge.ClearAllOwned();
+        assert(!unsafeNestedRetirement.ok &&
+            unsafeNestedRetirement.code == "authoritative_reset_retire_failed_after_commit");
+        assert(ReadText(expectedMod / "mod.usda") == ModLayer({}));
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+        assert(std::filesystem::is_directory(expectedMod / "textures"));
+        std::filesystem::remove(nestedReparse, reparseError);
+        assert(!reparseError);
+        const auto recoveredNestedRetirement = bridge.ClearAllOwned();
+        assert(recoveredNestedRetirement.ok);
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+    } else {
+        reparseError.clear();
+        const auto ordinaryNestedRetirement = bridge.ClearAllOwned();
+        assert(ordinaryNestedRetirement.ok);
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+    }
+
+    const auto rootReparseApply = bridge.ApplyLegacyMaterial(postResetRequest);
+    assert(rootReparseApply.ok && rootReparseApply.importedTextures.size() == 1);
+    reparseError.clear();
+    std::filesystem::remove_all(retiredTextures, reparseError);
+    assert(!reparseError);
+    reparseError.clear();
+    std::filesystem::create_directory_symlink(
+        externalTextureDirectory, retiredTextures, reparseError);
+    if (!reparseError) {
+        const auto unsafeRetirement = bridge.ClearAllOwned();
+        assert(!unsafeRetirement.ok &&
+            unsafeRetirement.code == "authoritative_reset_retire_failed_after_commit");
+        assert(ReadText(expectedMod / "mod.usda") == ModLayer({}));
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+        assert(std::filesystem::is_directory(expectedMod / "textures"));
+        std::filesystem::remove(retiredTextures, reparseError);
+        assert(!reparseError);
+        const auto recoveredRetirement = bridge.ClearAllOwned();
+        assert(recoveredRetirement.ok);
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+        assert(!std::filesystem::exists(expectedMod / "textures"));
+        assert(std::filesystem::is_directory(retiredTextures));
+    } else {
+        reparseError.clear();
+        const auto ordinaryRetirement = bridge.ClearAllOwned();
+        assert(ordinaryRetirement.ok);
+        assert(ReadText(externalTextureSentinel) == "outside texture sentinel");
+    }
+
+    ApplyRequest unsafe = request;
+    unsafe.profileId = "../outside";
+    assert(!bridge.ApplyLegacyMaterial(unsafe).ok);
+    unsafe = request;
+    unsafe.hashes = {"not-a-hash"};
+    assert(!bridge.ApplyLegacyMaterial(unsafe).ok);
+
+    // The active ledger parser never accepts paths outside the fixed profiles
+    // namespace. Authoritative reset can still recover from a malformed root,
+    // and its retirement cannot touch the referenced outside file.
+    const auto outsideSentinel = expectedMod.parent_path() / "outside.usda";
+    WriteText(outsideSentinel, "outside sentinel");
+    WriteText(expectedMod / "mod.usda",
+        "#usda 1.0\n(\n    subLayers = [\n"
+        "        @../outside.usda@\n    ]\n)\n");
+    const auto unsafeRootApply = bridge.ApplyLegacyMaterial(postResetRequest);
+    assert(!unsafeRootApply.ok && unsafeRootApply.code == "mod_index_read_failed");
+    assert(ReadText(outsideSentinel) == "outside sentinel");
+    const auto recoveredReset = bridge.ClearAllOwned();
+    assert(recoveredReset.ok);
+    assert(ReadText(expectedMod / "mod.usda") == ModLayer({}));
+    assert(ReadText(outsideSentinel) == "outside sentinel");
+
+    // AperturePBR exposes an anisotropy map. It has no tangent_texture input,
+    // so the native role, content-addressed name, and USDA token must agree.
+    assert(std::string(TextureRoleName(TextureRole::Anisotropy)) == "anisotropy");
+    ApplyRequest anisotropyRequest = request;
+    anisotropyRequest.profileId = "anisotropy_contract";
+    anisotropyRequest.hashes = {"00000000A11507F1"};
+    anisotropyRequest.material.textures.clear();
+    anisotropyRequest.material.textures.push_back(
+        {TextureRole::Anisotropy, source, {}});
+    const auto anisotropyApply = bridge.ApplyLegacyMaterial(anisotropyRequest);
+    assert(anisotropyApply.ok && anisotropyApply.layerPaths.size() == 1);
+    assert(anisotropyApply.importedTextures.size() == 1);
+    assert(anisotropyApply.importedTextures.front().filename().string().rfind(
+        "anisotropy_", 0) == 0);
+    const auto anisotropyLayer = ReadText(anisotropyApply.layerPaths.front());
+    assert(anisotropyLayer.find("asset inputs:anisotropy_texture") != std::string::npos);
+    assert(anisotropyLayer.find("tangent_texture") == std::string::npos);
+
+    // RTX Remix 1.5.2's AperturePBR_Opacity contract. Exercise every texture
+    // role and subsurface constant together so the unique-role bound, USDA
+    // input names, and MDL-declared colour spaces cannot drift independently.
+    assert(kTextureRoleCount == 11);
+    assert(std::string(TextureRoleName(TextureRole::SubsurfaceTransmittance)) ==
+           "subsurface_transmittance");
+    assert(std::string(TextureRoleName(TextureRole::SubsurfaceThickness)) ==
+           "subsurface_thickness");
+    assert(std::string(TextureRoleName(TextureRole::SubsurfaceScattering)) ==
+           "subsurface_scattering");
+    assert(std::string(TextureRoleName(TextureRole::SubsurfaceRadius)) ==
+           "subsurface_radius");
+
+    ApplyRequest aperture152Request = request;
+    aperture152Request.profileId = "aperture_152_contract";
+    aperture152Request.hashes = {"0000000015200001"};
+    aperture152Request.material.textures.clear();
+    for (std::size_t role = 0; role < kTextureRoleCount; ++role) {
+        aperture152Request.material.textures.push_back(
+            {static_cast<TextureRole>(role), source, {}});
+    }
+    aperture152Request.material.subsurfaceTransmittanceColor =
+        Vec3{0.1f, 0.2f, 0.3f};
+    aperture152Request.material.subsurfaceMeasurementDistance = 16.0f;
+    aperture152Request.material.subsurfaceSingleScatteringAlbedo =
+        Vec3{0.4f, 0.5f, 0.6f};
+    aperture152Request.material.subsurfaceVolumetricAnisotropy = -0.99f;
+    aperture152Request.material.subsurfaceRadius = Vec3{0.7f, 0.8f, 0.9f};
+    aperture152Request.material.subsurfaceRadiusScale = 1000.0f;
+    aperture152Request.material.subsurfaceMaxSampleRadius = 65504.0f;
+    aperture152Request.material.normalEncoding = 1;
+    // Explicit false must win over every legacy inference trigger below.
+    aperture152Request.material.enableThinFilm = false;
+    aperture152Request.material.thinFilmThickness = 200.0f;
+    aperture152Request.material.alphaIsThinFilmThickness = true;
+    aperture152Request.material.enableEmission = false;
+    aperture152Request.material.emissiveIntensity = 40.0f;
+    aperture152Request.material.preloadTextures = false;
+    aperture152Request.material.ignoreMaterial = true;
+    aperture152Request.material.blendEnabled = false;
+    aperture152Request.material.blendType = 8;
+    aperture152Request.material.subsurfaceDiffusionProfile = true;
+    aperture152Request.material.wrapModeU = 3;
+    aperture152Request.material.alphaTestType = 6;
+
+    const auto aperture152Apply = bridge.ApplyLegacyMaterial(aperture152Request);
+    assert(aperture152Apply.ok && aperture152Apply.layerPaths.size() == 1);
+    assert(aperture152Apply.importedTextures.size() == kTextureRoleCount);
+    const auto aperture152Layer = ReadText(aperture152Apply.layerPaths.front());
+    assert(HasTextureInput(aperture152Layer, "diffuse_texture", "sRGB"));
+    assert(HasTextureInput(aperture152Layer, "normalmap_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer, "anisotropy_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer, "reflectionroughness_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer, "metallic_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer, "height_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer, "emissive_mask_texture", "sRGB"));
+    assert(HasTextureInput(aperture152Layer,
+                           "subsurface_transmittance_texture", "sRGB"));
+    assert(HasTextureInput(aperture152Layer,
+                           "subsurface_thickness_texture", "raw"));
+    assert(HasTextureInput(aperture152Layer,
+                           "subsurface_single_scattering_texture", "sRGB"));
+    assert(HasTextureInput(aperture152Layer,
+                           "subsurface_radius_texture", "raw"));
+    assert(aperture152Layer.find(
+        "color3f inputs:subsurface_transmittance_color = (0.100000001, 0.200000003, 0.300000012)") !=
+        std::string::npos);
+    assert(aperture152Layer.find(
+        "float inputs:subsurface_measurement_distance = 16") != std::string::npos);
+    assert(aperture152Layer.find(
+        "color3f inputs:subsurface_single_scattering_albedo = (0.400000006, 0.5, 0.600000024)") !=
+        std::string::npos);
+    assert(aperture152Layer.find(
+        "float inputs:subsurface_volumetric_anisotropy = -0.99000001") !=
+        std::string::npos);
+    assert(aperture152Layer.find(
+        "color3f inputs:subsurface_radius = (0.699999988, 0.800000012, 0.899999976)") !=
+        std::string::npos);
+    assert(aperture152Layer.find(
+        "float inputs:subsurface_radius_scale = 1000") != std::string::npos);
+    assert(aperture152Layer.find(
+        "float inputs:subsurface_max_sample_radius = 65504") != std::string::npos);
+    assert(aperture152Layer.find("int inputs:encoding = 1") != std::string::npos);
+    assert(aperture152Layer.find("bool inputs:enable_thin_film = 0") !=
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:enable_thin_film = 1") ==
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:enable_emission = 0") !=
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:enable_emission = 1") ==
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:preload_textures = 0") !=
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:preload_textures = 1") ==
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:ignore_material = 1") !=
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:blend_enabled = 0") !=
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:blend_enabled = 1") ==
+        std::string::npos);
+    assert(aperture152Layer.find("bool inputs:subsurface_diffusion_profile = 1") !=
+        std::string::npos);
+    assert(aperture152Layer.find("int inputs:wrap_mode_u = 3") != std::string::npos);
+    assert(aperture152Layer.find("int inputs:alpha_test_type = 6") !=
+        std::string::npos);
+
+    // Every AlphaTestType and normal-map encoding value declared by the MDLs
+    // is accepted, while values immediately outside each enum remain invalid.
+    ApplyRequest enumRequest = aperture152Request;
+    enumRequest.profileId = "aperture_152_enums";
+    enumRequest.hashes = {"0000000015200002"};
+    enumRequest.material.textures.clear();
+    for (int alphaTest = 0; alphaTest <= 7; ++alphaTest) {
+        enumRequest.material.alphaTestType = alphaTest;
+        const auto enumApply = bridge.ApplyLegacyMaterial(enumRequest);
+        assert(enumApply.ok);
+    }
+    for (int encoding = 0; encoding <= 2; ++encoding) {
+        enumRequest.material.normalEncoding = encoding;
+        const auto enumApply = bridge.ApplyLegacyMaterial(enumRequest);
+        assert(enumApply.ok);
+    }
+    for (const int invalidEncoding : {-1, 3}) {
+        enumRequest.material.normalEncoding = invalidEncoding;
+        const auto enumApply = bridge.ApplyLegacyMaterial(enumRequest);
+        assert(!enumApply.ok && enumApply.code == "invalid_material");
+    }
+
+    // Check every new hard range just beyond the 1.5.2 MDL boundary.
+    auto invalid152 = aperture152Request;
+    invalid152.material.subsurfaceTransmittanceColor = Vec3{1.01f, 0.0f, 0.0f};
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceMeasurementDistance = 16.01f;
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceSingleScatteringAlbedo = Vec3{0.0f, -0.01f, 0.0f};
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceVolumetricAnisotropy = 1.0f;
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceRadius = Vec3{0.0f, 0.0f, 1.01f};
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceRadiusScale = 1000.01f;
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+    invalid152 = aperture152Request;
+    invalid152.material.subsurfaceMaxSampleRadius = 65504.01f;
+    assert(!bridge.ApplyLegacyMaterial(invalid152).ok);
+
+    // Protocol-1 requests without explicit flags retain their prior inferred
+    // writer behaviour. New requests can override every one of these above.
+    ApplyRequest legacyInference = request;
+    legacyInference.profileId = "legacy_flag_inference";
+    legacyInference.hashes = {"0000000015200003"};
+    legacyInference.material.textures.clear();
+    legacyInference.material.textures.push_back({TextureRole::Normal, source, {}});
+    legacyInference.material.emissiveIntensity = 1.0f;
+    legacyInference.material.thinFilmThickness = 100.0f;
+    const auto legacyInferenceApply = bridge.ApplyLegacyMaterial(legacyInference);
+    assert(legacyInferenceApply.ok);
+    const auto legacyInferenceLayer = ReadText(legacyInferenceApply.layerPaths.front());
+    assert(legacyInferenceLayer.find("bool inputs:preload_textures = 1") !=
+        std::string::npos);
+    assert(legacyInferenceLayer.find("int inputs:encoding = 2") != std::string::npos);
+    assert(legacyInferenceLayer.find("bool inputs:enable_emission = 1") !=
+        std::string::npos);
+    assert(legacyInferenceLayer.find("bool inputs:enable_thin_film = 1") !=
+        std::string::npos);
+    assert(legacyInferenceLayer.find("bool inputs:blend_enabled = 1") !=
+        std::string::npos);
+
+#ifdef _WIN32
+    const auto normalMipSource = root / "garrysmod" / "data" / "normal_mips.bmp";
+    WriteNormalMipFixture(normalMipSource);
+    ApplyRequest normalMipRequest = request;
+    normalMipRequest.profileId = "normal_mip_contract";
+    normalMipRequest.hashes = {"00000000A11CE001"};
+    normalMipRequest.material.textures.clear();
+    normalMipRequest.material.textures.push_back(
+        {TextureRole::Normal, normalMipSource, {}});
+    const auto normalMipApply = bridge.ApplyLegacyMaterial(normalMipRequest);
+    assert(normalMipApply.ok && normalMipApply.importedTextures.size() == 1);
+    std::ifstream normalDds(normalMipApply.importedTextures.front(), std::ios::binary);
+    normalDds.seekg(128 + 2 * 2 * 4);
+    std::uint8_t normalMip[4]{};
+    normalDds.read(reinterpret_cast<char*>(normalMip),
+                   static_cast<std::streamsize>(sizeof(normalMip)));
+    assert(normalDds);
+    const float mipX = normalMip[2] / 127.5f - 1.0f;
+    const float mipY = normalMip[1] / 127.5f - 1.0f;
+    const float mipZ = normalMip[0] / 127.5f - 1.0f;
+    const float mipLength = std::sqrt(mipX * mipX + mipY * mipY + mipZ * mipZ);
+    assert(mipLength > 0.98f && mipLength < 1.02f);
+    assert(normalMip[0] > 210 && normalMip[2] > 210);
+#endif
+
+    // The root ledger and active cache are bounded transactionally. Quota
+    // rejection must never replace the previously published root.
+    const auto profileQuotaRoot = root / "profile_quota";
+    std::filesystem::create_directories(profileQuotaRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(profileQuotaRoot / "rtx-remix" / "mods");
+    const auto profileQuotaSource =
+        profileQuotaRoot / "garrysmod" / "data" / "source.dds";
+    WriteMinimalDds(profileQuotaSource);
+    Config profileQuotaConfig;
+    profileQuotaConfig.gameRoot = profileQuotaRoot;
+    profileQuotaConfig.maxActiveProfiles = 128;
+    profileQuotaConfig.maxActiveTextureFiles = 1;
+    profileQuotaConfig.maxActiveTextureBytes =
+        std::filesystem::file_size(profileQuotaSource);
+    Bridge profileQuotaBridge(std::move(profileQuotaConfig));
+    ApplyRequest profileQuotaRequest;
+    profileQuotaRequest.profileId = "profile_quota";
+    profileQuotaRequest.material.roughness = 0.2f;
+    profileQuotaRequest.material.textures = {
+        {TextureRole::Albedo, profileQuotaSource, {}},
+    };
+    for (std::uint64_t index = 1; index <= 128; ++index) {
+        profileQuotaRequest.hashes.push_back(HexHash(0xA000000000000000ull + index));
+    }
+    assert(profileQuotaBridge.ApplyLegacyMaterial(profileQuotaRequest).ok);
+    profileQuotaRequest.material.roughness = 0.7f;
+    assert(profileQuotaBridge.ApplyLegacyMaterial(profileQuotaRequest).ok);
+    // A repeat prunes the inactive revisions created by the replacement while
+    // reusing the current immutable layers.
+    assert(profileQuotaBridge.ApplyLegacyMaterial(profileQuotaRequest).ok);
+    const auto profileQuotaMod = profileQuotaBridge.ModDirectory() / "mod.usda";
+    const auto profileQuotaRootBefore = ReadText(profileQuotaMod);
+    const auto profileFilesBefore = CountRegularFiles(
+        profileQuotaBridge.ModDirectory() / "profiles");
+    assert(profileFilesBefore == 128);
+    ApplyRequest profileOverflow = profileQuotaRequest;
+    profileOverflow.profileId = "profile_quota_overflow";
+    profileOverflow.hashes = {"B000000000000001"};
+    const auto profileOverflowResult =
+        profileQuotaBridge.ApplyLegacyMaterial(profileOverflow);
+    assert(!profileOverflowResult.ok && profileOverflowResult.code == "resource_limit");
+    assert(ReadText(profileQuotaMod) == profileQuotaRootBefore);
+    assert(CountRegularFiles(profileQuotaBridge.ModDirectory() / "profiles") ==
+           profileFilesBefore);
+    assert(CountRegularFilesRecursive(profileQuotaBridge.ModDirectory() / "textures") == 1);
+
+    const auto fileQuotaRoot = root / "file_quota";
+    std::filesystem::create_directories(fileQuotaRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(fileQuotaRoot / "rtx-remix" / "mods");
+    const auto fileQuotaSource = fileQuotaRoot / "garrysmod" / "data" / "source.dds";
+    WriteMinimalDds(fileQuotaSource);
+    Config fileQuotaConfig;
+    fileQuotaConfig.gameRoot = fileQuotaRoot;
+    fileQuotaConfig.maxActiveTextureFiles = 1;
+    Bridge fileQuotaBridge(std::move(fileQuotaConfig));
+    ApplyRequest fileQuotaBase;
+    fileQuotaBase.profileId = "file_quota";
+    fileQuotaBase.hashes = {"C000000000000001"};
+    fileQuotaBase.material.roughness = 0.4f;
+    assert(fileQuotaBridge.ApplyLegacyMaterial(fileQuotaBase).ok);
+    const auto fileQuotaMod = fileQuotaBridge.ModDirectory() / "mod.usda";
+    const auto fileQuotaRootBefore = ReadText(fileQuotaMod);
+    ApplyRequest tooManyTextureFiles = fileQuotaBase;
+    tooManyTextureFiles.material.textures = {
+        {TextureRole::Albedo, fileQuotaSource, {}},
+        {TextureRole::Normal, fileQuotaSource, {}},
+    };
+    const auto fileQuotaFailure =
+        fileQuotaBridge.ApplyLegacyMaterial(tooManyTextureFiles);
+    assert(!fileQuotaFailure.ok && fileQuotaFailure.code == "resource_limit");
+    assert(ReadText(fileQuotaMod) == fileQuotaRootBefore);
+    assert(CountRegularFiles(fileQuotaBridge.ModDirectory() / "profiles") == 1);
+    assert(CountRegularFilesRecursive(fileQuotaBridge.ModDirectory() / "textures") == 0);
+    tooManyTextureFiles.material.textures.resize(1);
+    assert(fileQuotaBridge.ApplyLegacyMaterial(tooManyTextureFiles).ok);
+    assert(CountRegularFilesRecursive(fileQuotaBridge.ModDirectory() / "textures") == 1);
+
+    const auto byteQuotaRoot = root / "byte_quota";
+    std::filesystem::create_directories(byteQuotaRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(byteQuotaRoot / "rtx-remix" / "mods");
+    const auto byteQuotaSource = byteQuotaRoot / "garrysmod" / "data" / "source.dds";
+    WriteMinimalDds(byteQuotaSource);
+    const auto oneTextureBytes = std::filesystem::file_size(byteQuotaSource);
+    Config byteQuotaConfig;
+    byteQuotaConfig.gameRoot = byteQuotaRoot;
+    byteQuotaConfig.maxActiveTextureBytes = oneTextureBytes;
+    Bridge byteQuotaBridge(std::move(byteQuotaConfig));
+    ApplyRequest byteQuotaFirst;
+    byteQuotaFirst.profileId = "byte_quota_a";
+    byteQuotaFirst.hashes = {"D000000000000001"};
+    byteQuotaFirst.material.textures = {
+        {TextureRole::Albedo, byteQuotaSource, {}},
+    };
+    assert(byteQuotaBridge.ApplyLegacyMaterial(byteQuotaFirst).ok);
+    const auto byteQuotaMod = byteQuotaBridge.ModDirectory() / "mod.usda";
+    const auto byteQuotaRootBefore = ReadText(byteQuotaMod);
+    ApplyRequest byteQuotaSecond = byteQuotaFirst;
+    byteQuotaSecond.profileId = "byte_quota_b";
+    byteQuotaSecond.hashes = {"D000000000000002"};
+    const auto byteQuotaFailure = byteQuotaBridge.ApplyLegacyMaterial(byteQuotaSecond);
+    assert(!byteQuotaFailure.ok && byteQuotaFailure.code == "resource_limit");
+    assert(ReadText(byteQuotaMod) == byteQuotaRootBefore);
+    assert(CountRegularFilesRecursive(byteQuotaBridge.ModDirectory() / "textures") == 1);
+    // Replacing the existing hash with an equal-size texture is valid even
+    // though the old cache file exists transiently until the next transaction.
+    byteQuotaSecond.hashes = byteQuotaFirst.hashes;
+    assert(byteQuotaBridge.ApplyLegacyMaterial(byteQuotaSecond).ok);
+    assert(ReadText(byteQuotaMod) != byteQuotaRootBefore);
+    assert(byteQuotaBridge.ApplyLegacyMaterial(byteQuotaSecond).ok);
+    assert(CountRegularFilesRecursive(byteQuotaBridge.ModDirectory() / "textures") == 1);
+
+    // An over-limit root is rejected for ordinary edits, but authoritative
+    // reset deliberately bypasses root parsing so it can always recover.
+    const auto recoveryRoot = root / "quota_recovery";
+    std::filesystem::create_directories(recoveryRoot / "garrysmod" / "data");
+    const auto recoveryMod =
+        recoveryRoot / "rtx-remix" / "mods" / "!advanced_material_editor";
+    std::filesystem::create_directories(recoveryMod / "profiles");
+    std::vector<std::string> recoveryProfiles;
+    for (std::uint64_t index = 1; index <= 129; ++index) {
+        const auto hash = HexHash(0xE000000000000000ull + index);
+        const auto id = "hash_" + hash + "_0000000000000001";
+        recoveryProfiles.push_back(id);
+        WriteText(recoveryMod / "profiles" / (id + ".usda"), LegacyLayer({hash}));
+    }
+    WriteText(recoveryMod / "mod.usda", ModLayer(recoveryProfiles));
+    Config recoveryConfig;
+    recoveryConfig.gameRoot = recoveryRoot;
+    recoveryConfig.maxActiveProfiles = 128;
+    Bridge recoveryBridge(std::move(recoveryConfig));
+    ApplyRequest rejectedRecoveryEdit;
+    rejectedRecoveryEdit.profileId = "quota_recovery";
+    rejectedRecoveryEdit.hashes = {"F000000000000001"};
+    const auto rejectedRecoveryResult =
+        recoveryBridge.ApplyLegacyMaterial(rejectedRecoveryEdit);
+    assert(!rejectedRecoveryResult.ok);
+    assert(recoveryBridge.ClearAllOwned().ok);
+    assert(ReadText(recoveryMod / "mod.usda") == ModLayer({}));
+
+    const auto invalidLimitRoot = root / "invalid_limit";
+    std::filesystem::create_directories(invalidLimitRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(invalidLimitRoot / "rtx-remix" / "mods");
+    Config invalidLimitConfig;
+    invalidLimitConfig.gameRoot = invalidLimitRoot;
+    invalidLimitConfig.maxActiveProfiles = 127;
+    Bridge invalidLimitBridge(std::move(invalidLimitConfig));
+    assert(!invalidLimitBridge.GetCapabilities().available);
+
+    // Validate legacy block-compressed layout math independently from the
+    // larger transaction suite: 5x3 DXT1 mips consume 16 + 8 + 8 bytes.
+    const auto ddsRoot = root / "dds_validation";
+    std::filesystem::create_directories(ddsRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(ddsRoot / "rtx-remix" / "mods");
+    const auto validDxt1 = ddsRoot / "garrysmod" / "data" / "valid_dxt1.dds";
+    WriteLegacyFourCcDds(validDxt1, TestFourCc('D', 'X', 'T', '1'), 5, 3, 3, 32);
+    Config ddsConfig;
+    ddsConfig.gameRoot = ddsRoot;
+    Bridge ddsBridge(std::move(ddsConfig));
+    ApplyRequest ddsRequest;
+    ddsRequest.profileId = "valid_dxt1";
+    ddsRequest.hashes = {"F000000000000003"};
+    ddsRequest.material.textures.push_back({TextureRole::Albedo, validDxt1, {}});
+    const auto validDxt1Result = ddsBridge.ApplyLegacyMaterial(ddsRequest);
+    assert(validDxt1Result.ok);
+    const auto validDdsRootText = ReadText(ddsBridge.ModDirectory() / "mod.usda");
+
+    const auto shortDxt1 = ddsRoot / "garrysmod" / "data" / "short_dxt1.dds";
+    WriteLegacyFourCcDds(shortDxt1, TestFourCc('D', 'X', 'T', '1'), 5, 3, 3, 31);
+    ApplyRequest invalidDdsRequest = ddsRequest;
+    invalidDdsRequest.profileId = "short_dxt1";
+    invalidDdsRequest.hashes = {"F000000000000004"};
+    invalidDdsRequest.material.textures.front().source = shortDxt1;
+    const auto shortDxt1Result = ddsBridge.ApplyLegacyMaterial(invalidDdsRequest);
+    assert(!shortDxt1Result.ok && shortDxt1Result.code == "invalid_dds");
+    assert(ReadText(ddsBridge.ModDirectory() / "mod.usda") == validDdsRootText);
+
+    const auto alphaPixelsOnly =
+        ddsRoot / "garrysmod" / "data" / "alpha_pixels_only.dds";
+    WriteMinimalDds(alphaPixelsOnly, 1, 1, 1, std::nullopt, 0x1u);
+    invalidDdsRequest.profileId = "alpha_pixels_only";
+    invalidDdsRequest.hashes = {"F000000000000005"};
+    invalidDdsRequest.material.textures.front().source = alphaPixelsOnly;
+    const auto alphaPixelsOnlyResult = ddsBridge.ApplyLegacyMaterial(invalidDdsRequest);
+    assert(!alphaPixelsOnlyResult.ok && alphaPixelsOnlyResult.code == "invalid_dds");
+    assert(ReadText(ddsBridge.ModDirectory() / "mod.usda") == validDdsRootText);
+
+    const auto ambiguousNumeric =
+        ddsRoot / "garrysmod" / "data" / "ambiguous_numeric_fourcc.dds";
+    WriteLegacyFourCcDds(ambiguousNumeric, 28, 1, 1, 1, 1);
+    invalidDdsRequest.profileId = "ambiguous_numeric_fourcc";
+    invalidDdsRequest.hashes = {"F000000000000006"};
+    invalidDdsRequest.material.textures.front().source = ambiguousNumeric;
+    const auto ambiguousNumericResult = ddsBridge.ApplyLegacyMaterial(invalidDdsRequest);
+    assert(!ambiguousNumericResult.ok && ambiguousNumericResult.code == "invalid_dds");
+    assert(ReadText(ddsBridge.ModDirectory() / "mod.usda") == validDdsRootText);
+
+    const auto overflowDxt1 =
+        ddsRoot / "garrysmod" / "data" / "overflow_dxt1.dds";
+    constexpr auto maximumU32 = std::numeric_limits<std::uint32_t>::max();
+    WriteLegacyFourCcDds(
+        overflowDxt1, TestFourCc('D', 'X', 'T', '1'), maximumU32, maximumU32, 1, 8);
+    Config overflowConfig;
+    overflowConfig.gameRoot = ddsRoot;
+    overflowConfig.maxTextureDimension = maximumU32;
+    Bridge overflowBridge(std::move(overflowConfig));
+    invalidDdsRequest.profileId = "overflow_dxt1";
+    invalidDdsRequest.hashes = {"F000000000000007"};
+    invalidDdsRequest.material.textures.front().source = overflowDxt1;
+    const auto overflowDxt1Result = overflowBridge.ApplyLegacyMaterial(invalidDdsRequest);
+    assert(!overflowDxt1Result.ok && overflowDxt1Result.code == "invalid_dds");
+    assert(ReadText(ddsBridge.ModDirectory() / "mod.usda") == validDdsRootText);
+
+    // Real Garry's Mod libraries are frequently installed below localized
+    // directory names. A valid DX10/BC7 texture must survive that path without
+    // ANSI narrowing or being mistaken for an unsafe source.
+#ifdef _WIN32
+    const auto unicodeRoot = root / std::filesystem::path(L"\u6750\u8D28\u6D4B\u8BD5");
+    const auto unicodeSource = unicodeRoot / "garrysmod" / "data" /
+        std::filesystem::path(L"\u8D34\u56FE.dds");
+#else
+    const auto unicodeRoot = root / std::filesystem::u8path(u8"\u6750\u8D28\u6D4B\u8BD5");
+    const auto unicodeSource = unicodeRoot / "garrysmod" / "data" /
+        std::filesystem::u8path(u8"\u8D34\u56FE.dds");
+#endif
+    std::filesystem::create_directories(unicodeRoot / "garrysmod" / "data");
+    std::filesystem::create_directories(unicodeRoot / "rtx-remix" / "mods");
+    WriteDx10Bc7Dds(unicodeSource);
+    Config unicodeConfig;
+    unicodeConfig.gameRoot = unicodeRoot;
+    Bridge unicodeBridge(std::move(unicodeConfig));
+    ApplyRequest unicodeRequest;
+    unicodeRequest.profileId = "unicode_bc7";
+    unicodeRequest.hashes = {"F000000000000002"};
+    unicodeRequest.material.textures.push_back(
+        {TextureRole::Albedo, unicodeSource, {}});
+    const auto unicodeResult = unicodeBridge.ApplyLegacyMaterial(unicodeRequest);
+    assert(unicodeResult.ok);
+    assert(unicodeResult.importedTextures.size() == 1);
+    assert(std::filesystem::is_regular_file(unicodeResult.importedTextures.front()));
+    assert(RootReferences(ReadText(unicodeBridge.ModDirectory() / "mod.usda"),
+                          unicodeResult.layerPath));
+
+    std::error_code cleanupError;
+    std::filesystem::remove_all(root, cleanupError);
+    std::cout << "advmat RTX writer tests passed\n";
+    return 0;
+}

--- a/source/module.cpp
+++ b/source/module.cpp
@@ -22,6 +22,8 @@
 #include <remix/remix.h>
 #include <remix/remix_c.h>
 #include "remixapi/remixapi.h"
+#include "advmat_rtx_bridge/bridge.h"
+#include "advmat_rtx_bridge/lua_bindings.h"
 #include "d3d9_texture_tracker.h"
 #include "patch_manager.h"
 #include "culling_patches.h"
@@ -34,6 +36,11 @@
 #include <globalconvars.h>
 #include "model_draw_hook.h"
 #include "material_pipeline/material_pipeline.h"
+#ifdef _WIN64
+#include <filesystem>
+#include <optional>
+#include <string>
+#endif
 
 #ifdef GMOD_MAIN
 extern IMaterialSystem* materials = NULL;
@@ -60,6 +67,17 @@ namespace {
     ConCommand* g_vramStatsCommand = nullptr;
     ICvar* g_commandCvar = nullptr;
     bool g_moduleClosing = false;
+
+    std::optional<std::filesystem::path> DiscoverExecutablePath() {
+        constexpr DWORD maxPathLength = 32768;
+        std::wstring buffer(maxPathLength, L'\0');
+        const DWORD length = GetModuleFileNameW(nullptr, buffer.data(), maxPathLength);
+        if (length == 0 || length >= maxPathLength) {
+            return std::nullopt;
+        }
+        buffer.resize(length);
+        return std::filesystem::path(buffer);
+    }
 
     void PrintVramStats() {
         remixapi_VramStats stats = {};
@@ -439,6 +457,17 @@ GMOD_MODULE_OPEN() {
 
         LUA->Pop();
 
+#ifdef _WIN64
+        const auto executable = DiscoverExecutablePath();
+        const auto gameRoot = executable
+            ? advmat::rtx_bridge::FindGameRootFromExecutable(*executable)
+            : std::nullopt;
+        if (!advmat::rtx_bridge::RegisterLua(
+                LUA, gameRoot.value_or(std::filesystem::path{}))) {
+            Warning("[AdvMat RTX Bridge] Failed to register Lua provider\n");
+        }
+#endif
+
         Msg("[gmRTX - Binary Module] Module initialization completed successfully!\n");
         return 0;
     }
@@ -454,6 +483,7 @@ GMOD_MODULE_CLOSE() {
 
 #ifdef _WIN64
         g_moduleClosing = true;
+        advmat::rtx_bridge::UnregisterLua(LUA);
         UnregisterTextureCleanupCommands();
 
         // Restore all runtime patches before shutdown


### PR DESCRIPTION
### Summary
This PR adds a Win64 native bridge that allows addons like [Advanced Material Editor](https://steamcommunity.com/sharedfiles/filedetails/?id=3793132326) to create persistent RTX Remix material replacements for captured Source texture hashes. Thus allowing the adjustment and editing of materials live in game without entering into RTX-Remix editor.

The bridge is integrated into `RTXFixesBinary` and exposes the versioned `AdvMatRTXBridge` protocol to client Lua. Existing Win32 behavior and the public Remix API remain unchanged.

### Changes
- Add `AdvMatRTXBridge` protocol 1 with:
  - `Capabilities`
  - `ApplyLegacyMaterial`
  - `ClearLegacyMaterial`
  - `ClearAllOwned`
- Generate and atomically publish RTX Remix USDA replacement layers.
- Import DDS textures and convert supported WIC images.
- Support PBR maps, constants, Remix material flags, filtering, blending, displacement, emission, subsurface parameters, and texture operations.
- Register the bridge only in Win64 builds.
- Add protocol, ownership, and safety documentation.
- Add an isolated CMake writer test target and x64 CI coverage.

### Safety and isolation

The bridge owns only:

```text
rtx-remix/mods/!advanced_material_editor/
```

It does not modify or depend on `~gmod_topbr`.

Additional protections include:

- Canonical path containment checks.
- Reparse-point and path-redirection rejection.
- Atomic, content-revisioned USDA publication.
- Exact 64-bit texture hashes preserved as strings.
- Transactional rollback on failed writes.
- Per-texture and active-profile resource limits.
- Structural DDS and mip-payload validation.
- Corrupted content-addressed cache repair.
- Unicode Windows path support.
- Authoritative cleanup between server sessions.

Protocol 1 is commit-only. It does not claim reversible live preview support.

### Compatibility

- Win64: bridge compiled and registered.
- Win32: bridge sources and dependencies are excluded.
- Existing Remix API and material-pipeline behavior are unchanged.
- The Advanced Material Editor addon remains a separate repository.

### Testing

Locally verified with:
- Ran a few in-game test which proven to be working. 
- Release-mode writer regression tests.
- Strict compilation using `-Wall -Wextra -Wpedantic -Werror`.
- Standalone Lua binding compilation.
- Premake Win32/x64 configuration inspection.
- DDS tests covering legacy DXT1 mip chains, DX10/BC7, truncated payloads, malformed flags, arithmetic overflow, cache corruption, and Unicode paths.
- `git diff --check`.

The workflow also runs the writer suite with Visual Studio 2022 for x64.